### PR TITLE
Do not use git exec path unless necessary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,12 +11,19 @@ at ``~/.git-secrets``, then the commit is rejected.
 Installing
 ----------
 
-First clone the repository. Then run the following command::
+Clone the repository and run ``install.sh``::
 
     ./install.sh
 
-The ``install.sh`` script will install a global ``git secrets`` git subcommand
-that can be used ad-hoc with any git project.
+``install.sh`` script will install a global ``git secrets`` git subcommand that
+can be used ad-hoc with any git project. You can pass the path to where the
+script should be installed as an argument to ``install.sh``::
+
+    ./install.sh /path/to/where/to/install
+
+If no path is provided, ``install.sh`` will attempt to install ``git-secrets``
+to ``/usr/local/bin`` if is available, and as a last resort to the directory
+returned from ``git --exec-path``.
 
 The ``git-secrets scan`` command accepts the path to a file to check and will
 report if any of the prohibited matches are found in the file.

--- a/install.sh
+++ b/install.sh
@@ -1,19 +1,35 @@
 #!/usr/bin/env bash
 #
 # Installs the `git secrets` command.
+#
+# You can pass the path to the directory to install the script in argument 1.
+#
+# If no directory is passed, then the script will install the git subcommand to
+# /usr/local/bin (if available) or as a last resort, git --exec-path.
 
 pass() { echo "$(tput setaf 2) ✓ $1$(tput sgr 0)"; }
 fail() { echo "$(tput setaf 1) ✗ $1$(tput sgr 0)"; exit 1; }
 warn() { echo "$(tput setaf 3) - $1$(tput sgr 0)"; }
 
 install_secrets() {
-  cp git-secrets.sh "$1" && chmod +x "$1"
+  path="$1/git-secrets"
+  cp git-secrets.sh "${path}"
+  chmod +x "${path}"
 }
 
-command_path="$(git --exec-path)"/git-secrets
-install_secrets "${command_path}" \
-  && pass "Installed git-secrets command at ${command_path}" \
-  || fail "Could not install git-secrets at ${command_path}"
+INSTALL_DIR="${1}"
+
+if [ ! -z "${INSTALL_DIR}" ]; then
+  [ ! -d "${INSTALL_DIR}" ] && fail "${INSTALL_DIR} does not exist"
+elif [ -d "/usr/local/bin" ]; then
+  INSTALL_DIR="/usr/local/bin"
+else
+  INSTALL_DIR="$(git --exec-path)"
+fi
+
+install_secrets "${INSTALL_DIR}" \
+  && pass "Installed git-secrets command at ${INSTALL_DIR}" \
+  || fail "Could not install git-secrets at ${INSTALL_DIR}"
 
 [ -f "${HOME}/.git-secrets" ] \
   && pass "Found global secrets file at ${HOME}/.git-secrets" \


### PR DESCRIPTION
Updating the install script to try to use /usr/local/bin before installing to `git --exec-path`. This allows the script to remain installed even after upgrading git. You can also now provide a path to where the file should be installed.

@jamesls 
