### PR TITLE
Refactoring to be more like other git subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CHANGELOG
 
-## 0.0.1 - TBD
+## 1.0.0 - TBD
 
-* Initial release.
+* Initial release of ``git-secrets``.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,13 @@ help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  test     to perform unit tests."
 
+# We use bats for testing: https://github.com/sstephenson/bats
 test:
 	test/bats/bin/bats test/
 
-.PHONY: help test
+# The man page is completely derived from README.rst. Edits to
+# README.rst require a rebuild of the man page.
+man:
+	rst2man.py README.rst > git-secrets.1
+
+.PHONY: help test man

--- a/git-secrets
+++ b/git-secrets
@@ -1,34 +1,9 @@
 #!/usr/bin/env bash
 declare -r PATTERNS="$(git config --get-all secrets.patterns)"
 declare -r ALLOWED_PATTERNS="$(git config --get-all secrets.allowed)"
-declare -r MAIN_SPEC="\
-usage: git secrets scan [--file=]
-   or: git secrets install [--repo=]
-
-   scan       Scans a file for prohibited patterns
-   install    Installs git hooks for a repository"
-
-declare -r INSTALL_SPEC="\
-git secrets install [(-d | --dir=...)] [-h|--help]
-
-Installs pre-commit and commit-msg hooks for the given repository.
-If no repository argument is provided, then the command attempts
-to install hooks to a git repository in the working directory.
---
-d,dir=      Optional path to a repository for which to install hooks
-h,help    show help message"
-
-declare -r SCAN_SPEC="\
-git secrets scan (-f | --file ...)
-
-Scans the given file for a list of prohibited patterns.
---
-f,file=           Path to a file to scan for secrets. Pass - to scan stdin.
-h,help            show help message"
-
 declare -r PROHIBITED_MSG="\
 
-[ERROR] Matched prohibited pattern
+[ERROR] Matched one or more prohibited patterns
 
 Possible mitigations:
 
@@ -37,40 +12,62 @@ Possible mitigations:
 - List your configured allowed patterns: git config --get-all secrets.allowed
 - Use --no-verify if this is a one-time false positive
 "
+declare -r NONGIT_OK=1 OPTIONS_SPEC="\
+git secrets --scan <files>...
+git secrets --install [-d | --dir=<repo>]
+--
+h,help     Show help message
+scan       Scans <files> for prohibited patterns
+install    Installs git hooks for repo
+d,dir=     Used with --install to specify the path to repo
+commit_msg_hook* commit-msg hook (internal only)
+pre_commit_hook* pre-commit hook (internal only)
+prepare_commit_msg_hook* prepare-commit-msg hook (internal only)"
 
-check_pattern() {
-  local -r pattern="$1" filename="$2" inverse="$3"
-  if [ -z "${inverse}" ]; then
-    GREP_OPTIONS= LC_ALL=C grep -nwHE "${pattern}" "${filename}"
-  else
-    # Extract matches then determine with a negative grep if they're allowed.
-    GREP_OPTIONS= LC_ALL=C grep -nwHE "${pattern}" "${filename}" \
-      | GREP_OPTIONS= LC_ALL=C grep -Ev "${inverse}"
-  fi
-}
+# Include the git setup script. This parses and normalized CLI arguments.
+. $(git --exec-path)/git-sh-setup
 
 scan() {
+  local -r file="$1"
   [ -z "${PATTERNS}" ] && return 0
   if [ -z "${ALLOWED_PATTERNS}" ]; then
-    check_pattern "${PATTERNS}" $1 && return 1 || return 0
+    # When no allowed patterns are found, we can simply do a search.
+    GREP_OPTIONS= LC_ALL=C grep -nwHE "${PATTERNS}" "${file}" && return 1
+  else
+    # Extract matches then determine with a negative grep if they're allowed.
+    GREP_OPTIONS= LC_ALL=C grep -nwHE "${PATTERNS}" "${file}" \
+      | GREP_OPTIONS= LC_ALL=C grep -Ev "${ALLOWED_PATTERNS}" && return 1
   fi
-  check_pattern "${PATTERNS}" $1 "${ALLOWED_PATTERNS}" && return 1 || return 0
+  return 0
 }
 
+# Scans all of the files in a list. Dies after scanning all if any match.
+scan_files() {
+  local found_match=0
+  for file in $@; do
+    # Skip directories
+    if [ ! -d "${file}" ]; then
+      if [ "${file}" != '-' ] && [ ! -f "${file}" ]; then
+        die "File not found: ${file}"
+      fi
+      scan "$file" || found_match=1
+    fi
+  done
+  [ "$found_match" -eq 0 ] && exit 0
+  die "$PROHIBITED_MSG"
+}
+
+# Scans a commit message, passed in the path to a file.
 commit_msg_hook() {
-  scan "$1" || die "(commit-msg)" $'\n' "$PROHIBITED_MSG"
+  scan "$1" || die "$PROHIBITED_MSG"
 }
 
-# Scans a commit for prohibited patterns.
+# Scans all files that are about to be committed.
 pre_commit_hook() {
   local file found_match=0 rev="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
   # Diff against HEAD if this is not the first commit in the repo.
   [ git rev-parse --verify HEAD >/dev/null 2>&1 ] && rev="HEAD"
-  for file in $(git diff-index --name-only --cached $rev --); do
-    scan "$file" || found_match=1
-  done
-  [ $found_match -eq 0 ] && exit 0
-  die "(pre-commit)" $'\n' "$PROHIBITED_MSG"
+  scan_files "$(git diff-index --name-only --cached $rev --)"
 }
 
 # Determines if merging in a commit will introduce tainted history.
@@ -83,18 +80,15 @@ prepare_commit_msg_hook() {
       local dest="${branch#refs/heads/}"    # cut out "refs/heads"
       say "Checking if merging ${sha} into ${dest} adds prohibited history"
       git log "${dest}".."${sha}" -p \
-        | "$0" scan -f - || die "(prepare-commit-msg)" $'\n' "$PROHIBITED_MSG"
+        | "$0" --scan - || die "$PROHIBITED_MSG"
       ;;
     *) ;;
   esac
 }
 
-# Git hook installation functions
-#######################################################################
-
 # Determines the approriate path for a hook to be installed
 # This function respects any found $hook.d directories.
-determine_hook_path() {
+determine_hook_install_path() {
   local -r hook="$1" path="$2"
   local dest="${path}/.git/hooks/${hook}"
   local -r debian_dir="${path}/.git/hooks/${hook}.d"
@@ -108,48 +102,42 @@ install_hook() {
   [ -z "${dest}" ] && die "[ERR]  Expects the path to a file"
   [ -d "$(dirname ${dest})" ] || die "[ERR]  Directory not found: ${dest}"
   echo "#!/usr/bin/env bash" > "${dest}"
-  echo "git secrets ${cmd} \"\$@\"" >> "${dest}"
+  echo "git secrets --${cmd} \"\$@\"" >> "${dest}"
   chmod +x "${dest}"
   say "[OK]   Installed ${name} hook to ${dest}" $'\n'
 }
 
-install_hooks() {
+install_all_hooks() {
   local dest git_repo="$1"
-  dest=$(determine_hook_path "commit-msg" "${git_repo}")
+  dest=$(determine_hook_install_path "commit-msg" "${git_repo}")
   install_hook "${dest}" "commit-msg" "commit_msg_hook"
-  dest=$(determine_hook_path "pre-commit" "${git_repo}")
+  dest=$(determine_hook_install_path "pre-commit" "${git_repo}")
   install_hook "${dest}" "pre-commit" "pre_commit_hook"
-  dest=$(determine_hook_path "prepare-commit-msg" "${git_repo}")
+  dest=$(determine_hook_install_path "prepare-commit-msg" "${git_repo}")
   install_hook "${dest}" "prepare-commit-msg" "prepare_commit_msg_hook"
   say "Successfully installed git hooks"
 }
 
-# Dispatch to the appropriate functions
-#######################################################################
+declare -r COMMAND="$1"; shift
 
-CMD="${1:--h}"; shift
-# Determine the approriate options spec and load git-sh helpers.
-[ "$CMD" == 'scan' ] && OPTIONS_SPEC="$SCAN_SPEC"
-[ "$CMD" == 'install' ] && OPTIONS_SPEC="$INSTALL_SPEC"
-NONGIT_OK=1 # Allow the command to run outside of a git repo.
-. $(git --exec-path)/git-sh-setup
-
-case "$CMD" in
-  scan)
-    [ "$1" != '-f' ] && die "-f | --file is required"
-    [ "$2" != '-' ] && [ ! -f "$2" ] && die "File not found: $2"
-    scan "$2" || die "${PROHIBITED_MSG}"
+case "${COMMAND}" in
+  -h|--help|--) "$0" -h; exit 0 ;;
+  --commit_msg_hook|--pre_commit_hook|--prepare_commit_msg_hook)
+    # Shift off "--", which was added by git option parsing.
+    shift
+    # Strip the leading "--" from the hook function name.
+    ${COMMAND:2} "$@"
     ;;
-  install)
-    case "$1" in
-      --) dir=$(git rev-parse --show-toplevel) || die "Not in a git repo" ;;
-      -d) dir="$2" ;;
-      *) say "Invalid argument"; "$0" install -h; exit 129 ;;
-    esac
-    [ ! -d "${dir}" ] && die "Directory not found: ${dir}"
-    install_hooks "${dir}"
+  --scan)
+    [ "$1" != "--" ] && die "Unexpected argument: $1"
+    shift
+    [ $# -eq 0 ] && die "No files provided to scan"
+    scan_files "$@"
     ;;
-  commit_msg_hook|pre_commit_hook|prepare_commit_msg_hook) $CMD "$@" ;;
-  -h) printf "$MAIN_SPEC\n" ;;
-  *) echo "Unknown command: $CMD" && "$0" -h && exit 129 ;;
+  --install)
+    [ "$1" == "-d" ] && repo="$2" || repo="."
+    [ -d "${repo}" ] || die "Directory not found: ${repo}"
+    install_all_hooks "${repo}"
+    ;;
+  *) echo "Unknown option: ${option}" && "$0" -h ;;
 esac

--- a/git-secrets.1
+++ b/git-secrets.1
@@ -1,0 +1,474 @@
+.\" Man page generated from reStructuredText.
+.
+.TH GIT-SECRETS  "" "" ""
+.SH NAME
+git-secrets \- 
+.
+.nr rst2man-indent-level 0
+.
+.de1 rstReportMargin
+\\$1 \\n[an-margin]
+level \\n[rst2man-indent-level]
+level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
+-
+\\n[rst2man-indent0]
+\\n[rst2man-indent1]
+\\n[rst2man-indent2]
+..
+.de1 INDENT
+.\" .rstReportMargin pre:
+. RS \\$1
+. nr rst2man-indent\\n[rst2man-indent-level] \\n[an-margin]
+. nr rst2man-indent-level +1
+.\" .rstReportMargin post:
+..
+.de UNINDENT
+. RE
+.\" indent \\n[an-margin]
+.\" old: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.nr rst2man-indent-level -1
+.\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.in \\n[rst2man-indent\\n[rst2man-indent-level]]u
+..
+.sp
+Prevents you from committing passwords and other sensitive information to a
+git repository.
+.SH SYNOPSIS
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git secrets \-\-install [\-d | \-\-dir <repo>]
+git secrets \-\-scan <files>...
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SH DESCRIPTION
+.sp
+\fBgit\-secrets\fP scans commits, commit messages, and \fB\-\-no\-ff\fP merges to
+prevent adding secrets into your git repositories. If a commit,
+commit message, or any commit in a \fB\-\-no\-ff\fP merge history matches one of
+your configured prohibited regular expression patterns, then the commit is
+rejected.
+.SS Installing git\-secrets
+.sp
+It is recommended to run the \fBinstall.sh\fP script from the
+\fI\%git\-secrets\fP repository to install
+\fBgit\-secrets\fP\&. \fBinstall.sh\fP will copy \fBgit\-secrets\fP to the appropriate
+path (either \fB/usr/local/bin\fP or \fB$(git \-\-exec\-path)\fP), and will ask you
+through a series of prompts if you would like to seed you secrets configuration
+with common secrets. This includes scanning for AWS credentials, AWS account
+IDs, and other pieces of information found in your git config.
+.sp
+\fBWARNING:\fP
+.INDENT 0.0
+.INDENT 3.5
+You\(aqre not done yet! You MUST install the git hooks for every repo that
+you wish to use with \fBgit secrets \-\-install\fP\&.
+.UNINDENT
+.UNINDENT
+.SH OPTIONS
+.SS Operation Modes
+.sp
+Each of these options must appear first on the command line.
+.INDENT 0.0
+.TP
+.B \-\-install
+Installs hooks for a repository. Once the hooks are installed for a git
+repository, commits and non\-ff merges for that repository will be prevented
+from committing secrets.
+.sp
+Usage: \fBgit secrets \-\-install [\-d | \-\-dir <repo>]\fP
+.TP
+.B \-\-scan
+Scans one or more files for secrets. When a file contains a secret, the
+matched text from the file being scanned will be written to stdout and the
+script will exit with a non\-zero RC. Each matched line will be written with
+the name of the file that matched, a colon, the line number that matched,
+a colon, and then the line of text that matched.
+.sp
+Usage: \fBgit secrets \-\-scan <files>...\fP
+.UNINDENT
+.SS Options for \fB\-\-install\fP
+.INDENT 0.0
+.TP
+.B \-d\fP,\fB  \-\-dir
+When provided, installs git hooks to the given repository. The current
+directory is assumed if \fB\-\-dir\fP is not provided.
+.sp
+The following git hooks are installed:
+.INDENT 7.0
+.IP 1. 3
+\fBpre\-commit\fP: Used to check if any of the files changed in the commit
+use prohibited patterns.
+.IP 2. 3
+\fBcommit\-msg\fP: Used to determine if a commit message contains a
+prohibited patterns.
+.IP 3. 3
+\fBprepare\-commit\-msg\fP: Used to determine if a merge commit will
+introduce a history that contains a prohibited pattern at any point.
+Please note that this hook is only invoked for non fast\-forward merges.
+.UNINDENT
+.sp
+\fBNOTE:\fP
+.INDENT 7.0
+.INDENT 3.5
+Git only allows a single script to be executed per hook. If the
+repository contains Debian style subdirectories like \fBpre\-commit.d\fP
+and \fBcommit\-msg.d\fP, then the git hooks will be installed into these
+directories, which assumes that you\(aqve configured the corresponding
+hooks to execute all of the scripts found in these directories. If
+these git subdirectories are not present, then the git hooks will be
+installed to the git repo\(aqs \fB\&.git/hooks\fP directory, overwriting any
+previously configured hook. In the event that the hooks are
+overwritten, a warning will be written to stdout.
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.SS Examples
+.sp
+Install git hooks to the current directory:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+cd /path/to/my/repository
+git secrets \-\-install
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Install git hooks to a repository other than the current directory:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git secrets \-\-install \-d /path/to/my/repository
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SS Options for \fB\-\-scan\fP
+.INDENT 0.0
+.TP
+.B <files>...
+The path to one or more files on disk to scan for secrets.
+.UNINDENT
+.SS Examples
+.sp
+Scans a file for secrets:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git secrets \-\-scan /path/to/file
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Scans multiple files for secrets:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git secrets \-\-scan /path/to/file /path/to/other/file
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+You can scan by globbing:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git secrets \-\-scan /path/to/directory/*
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SH DEFINING PROHIBITED PATTERNS
+.sp
+egrep compatible regular expressions are used to determine if a commit or
+commit message contains any prohibited patterns. These regular expressions are
+defined using the \fBgit config\fP command. It is important to note that
+different systems use different versions of egrep. For example, when running on
+OS X, you will use a different version of egrep than when running on something
+like Ubuntu (BSD vs GNU).
+.sp
+\fBNOTE:\fP
+.INDENT 0.0
+.INDENT 3.5
+You can run the \fBinstall.sh\fP script at any time to add a number of
+pre\-configured patterns to your list of prohibited regular expressions,
+including AWS access keys and known AWS credentials stored in
+\fB~/.aws/credentials\fP\&.
+.UNINDENT
+.UNINDENT
+.sp
+You can add prohibited regular expression patterns to your git config by
+running the following command:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git config \-\-add secrets.patterns \(aqmy regex pattern\(aq
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+You can list the patterns that have been configured using the following
+command:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git config \-\-get\-all secrets.patterns
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Patterns will by default be added to the local git repository only. Use the
+\fB\-\-global\fP option to add the pattern to your global list of prohibited
+patterns:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git config \-\-global \-\-add secrets.patterns \(aqmy regex pattern\(aq
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.SH IGNORING FALSE-POSITIVES
+.sp
+Sometimes a regular expression might match false positives. For example, git
+commit SHAs look a lot like AWS access keys. You can specify many different
+regular expression patterns as false positives using the following command:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git config \-\-add secrets.allowed \(aqmy regex pattern\(aq
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+First, git\-secrets will extract all lines from a file that contain a prohibited
+match. Included in the matched results will be the full path to the name of
+the file that was matched, followed \(aq:\(aq, followed by the line number that was
+matched, followed by the entire line from the file that was matched by a secret
+pattern. Then, if you\(aqve defined \fBsecrets.allowed\fP regular expressions,
+git\-secrets will check to see if all of the matched lines match at least one of
+your registered \fBsecrets.allowed\fP regular expressions. If all of the lines
+that were flagged as secret are canceled out by an allowed match, then the
+subject text does not contain any secrets. If any of the matched lines are not
+matched by an allowed regular expression, then git\-secrets will fail the
+commit/merge/message.
+.sp
+\fBIMPORTANT:\fP
+.INDENT 0.0
+.INDENT 3.5
+Just as it is a bad practice to add \fBsecrets.patterns\fP that are too
+greedy, it is also a bad practice to add \fBsecrets.allowed\fP patterns that
+are too forgiving. Be sure to test out your patterns using ad\-hoc calls to
+\fBgit secrets \-\-scan $filename\fP to ensure they are working as intended.
+.UNINDENT
+.UNINDENT
+.SS Example walkthrough
+.sp
+Let\(aqs take a look at an example. Given the following subject text (stored in
+\fB/tmp/example\fP):
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+This is a test!
+password=ex@mplepassword
+password=******
+More test...
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+And the following registered \fBsecrets.patterns\fP and \fBsecrets.allowed\fP:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git config \-\-add secrets.patterns \(aqpassword\es*=\es*.+\(aq
+git config \-\-add secrets.allowed \(aqex@mplepassword\(aq
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Running \fBgit secrets \-\-scan /tmp/example\fP, the result will
+result in the following error output:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+/tmp/example:3:password=******
+
+[ERROR] Matched prohibited pattern
+
+Possible mitigations:
+
+\- Mark false positives as allowed using: git config \-\-add secrets.allowed ...
+\- List your configured patterns: git config \-\-get\-all secrets.patterns
+\- List your configured allowed patterns: git config \-\-get\-all secrets.allowed
+\- Use \-\-no\-verify if this is a one\-time false positive
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Breaking this down, the \fBsecrets.patterns\fP value of \fBpassword\es*=\es*.+\fP
+will match the following lines:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+/tmp/example:2:password=ex@mplepassword
+/tmp/example:3:password=******
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+\&...But the first match will be filtered out due to the fact that it matches the
+\fBsecrets.allowed\fP regular expression of \fBex@mplepassword\fP\&. Because
+there is still a remaining line that did not match, it is considered a secret.
+.sp
+Because that matching lines are placed on lines that start with the filename
+and line number (e.g., \fB/tmp/example:3:...\fP), you can create
+\fBsecrets.allowed\fP patterns that take filenames and line numbers into account
+in the regular expression. For example, you could whitelist an entire file
+using something like:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git config \-\-add secrets.allowed \(aq/tmp/example:.*\(aq
+git secrets \-\-scan /tmp/example && echo $?
+# Outputs: 0
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Alternatively, you could whitelist a specific line number of a file if that
+line is unlikely to change using something like the following:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git config \-\-add secrets.allowed \(aq/tmp/example:3:.*\(aq
+git secrets \-\-scan /tmp/example && echo $?
+# Outputs: 0
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Keep this in mind when creating \fBsecrets.allowed\fP patterns to ensure that
+your allowed patterns are not inadvertantly matched due to the fact that the
+filename is included in the subject text that allowed patterns are matched
+against.
+.sp
+\fBNOTE:\fP
+.INDENT 0.0
+.INDENT 3.5
+At the implementation level, we use \fBgrep\fP to first extract matches, then
+a negative grep using the \fB\-v\fP option to check if all of the extracted
+matches were filtered out by an allowed pattern.
+.UNINDENT
+.UNINDENT
+.SS Manually editing your git config
+.sp
+You may find that it\(aqs easier to simply edit your git config file directly
+rather than executing multiple \fBgit config \-\-add\fP commands from the command
+line. You can edit a project\(aqs config file using the following command:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+git config \-e
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Simply add a new ini section called "secrets" and place each prohibited
+regular expression line using \fBpattern=<regex>\fP\&. For example, your git
+config might look something like this:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+[core]
+    repositoryformatversion = 0
+    filemode = true
+    bare = false
+    logallrefupdates = true
+    ignorecase = true
+    precomposeunicode = true
+[remote "origin"]
+    url = git@github.com:foo/bar
+    fetch = +refs/heads/*:refs/remotes/origin/*
+[secrets]
+    patterns = [A\-Z0\-9]{20}
+    patterns = (\e"|\(aq)?(AWS_|aws_)?(SECRET|secret)(_ACCESS|_access)?_(KEY|key)(\e"|\(aq)?\e\es*(=|:|=>)\e\es*(\e"|\(aq)?[A\-Za\-z0\-9/\e\e+=]{40}(\e"|\(aq)?
+    patterns = (\e"|\(aq)?(AWS_|aws_)?(ACCOUNT|account)(_ID|_id)?(\e"|\(aq)?\e\es*(=|:|=>)\e\es*(\e"|\(aq)?[0\-9]{4}\e\e\-?[0\-9]{4}\e\e\-?[0\-9]{4}(\e"|\(aq)?
+    ; AWS example key
+    allowed = AKIAIOSFODNN7EXAMPLE
+    ; AWS example secret key
+    allowed = wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+More information on git configuration can be found in the
+\fI\%git documentation\fP\&.
+.SH SKIPPING VALIDATION
+.sp
+Use the \fB\-\-no\-verify\fP option in the event of a false\-positive match in a
+commit, merge, or commit message. This will skip the execution of the
+git hook and allow you to make the commit or merge.
+.SH ABOUT
+.INDENT 0.0
+.IP \(bu 2
+Author: Michael Dowling <\fI\%https://github.com/mtdowling\fP>
+.IP \(bu 2
+Issue tracker: This project\(aqs source code and issue tracker can be found at
+\fI\%https://github.com/awslabs/git\-secrets\fP
+.UNINDENT
+.\" Generated by docutils manpage writer.
+.

--- a/install.sh
+++ b/install.sh
@@ -107,6 +107,11 @@ if [ ! -z "${INSTALL_DIR}" ]; then
 elif [ -d "/usr/local/bin" ]; then
   # Use /usr/local/bin as the directory if it exists.
   INSTALL_DIR="/usr/local/bin"
+  # Install the man page because we know /usr/local exits.
+  if [ -d '/usr/local/share/man/man1' ]; then
+    cp git-secrets.1 /usr/local/share/man/man1/git-secrets.1 \
+      && pass "Copied man page to /usr/local/share/man/man1"
+  fi
 else
   # Fall back to using git --exec-path
   INSTALL_DIR="$(git --exec-path)"
@@ -117,13 +122,7 @@ cp git-secrets "${path}" && chmod +x "${path}" \
   && pass "Installed git-secrets command at ${INSTALL_DIR}/git-secrets" \
   || fail "Could not install git-secrets at ${INSTALL_DIR}/git-secrets"
 
-# 2) Call help to ensure it installed correctly
-########################################################
-git secrets -h > /dev/null 2>&1 \
-  && pass "git-secrets has been installed successfully" \
-  || fail "git-secrets did not install correctly"
-
-# 3) Import common patterns from git configs
+# 2) Import common patterns from git configs
 ########################################################
 git_ini_checks=('user.email' 'github.user' 'github.token')
 for check in "${git_ini_checks[@]}"; do
@@ -135,7 +134,7 @@ for check in "${git_ini_checks[@]}"; do
   fi
 done
 
-# 4) Add common AWS patterns
+# 3) Add common AWS patterns
 ########################################################
 if prompt "Add common AWS patterns (keys, secrets, account ID, etc.)?"; then
   # Reusable regex patterns
@@ -148,7 +147,7 @@ if prompt "Add common AWS patterns (keys, secrets, account ID, etc.)?"; then
   add_allowed 'Example Secret Access Key' "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 fi
 
-# 5) Import passwords from ~/.aws/credentials file
+# 4) Import passwords from ~/.aws/credentials file
 ########################################################
 if [ -x "$(which aws 2>&1)" ] \
       && [ -f ~/.aws/credentials ] \
@@ -163,10 +162,10 @@ if [ -x "$(which aws 2>&1)" ] \
   done
 fi
 
-# 6) Last step: ensure secrets can scan correctly
+# 5) Last step: ensure secrets can scan correctly
 ########################################################
 echo
-echo '' | git secrets scan -f - \
+echo '' | git secrets --scan - \
   && pass 'Successfully installed' \
   || fail 'Failed to install correctly'
 echo

--- a/test/commit-msg.bats
+++ b/test/commit-msg.bats
@@ -5,9 +5,10 @@ load test_helper
 @test "Rejects commit messages with prohibited patterns" {
   repo_run install.sh
   setup_good_repo
-  repo_run git-secrets install -d $TEST_REPO
+  repo_run git-secrets --install -d $TEST_REPO
   cd $TEST_REPO
   run git commit -m '@todo in the message??'
+  echo "$output" > /tmp/output
   [ $status -eq 1 ]
   [ "${lines[0]}" == ".git/COMMIT_EDITMSG:1:@todo in the message??" ]
   delete_repo
@@ -16,7 +17,7 @@ load test_helper
 @test "Allows commit messages that do not match a prohibited pattern" {
   repo_run install.sh
   setup_good_repo
-  repo_run git-secrets install -d $TEST_REPO
+  repo_run git-secrets --install -d $TEST_REPO
   cd $TEST_REPO
   run git commit -m 'This is OK'
   [ $status -eq 0 ]

--- a/test/install.bats
+++ b/test/install.bats
@@ -4,7 +4,7 @@ load test_helper
 
 @test "Installs git secrets" {
   run ./install.sh
-  run git secrets -h
+  run git secrets
   [ $status -eq 0 ]
 }
 

--- a/test/pre-commit.bats
+++ b/test/pre-commit.bats
@@ -5,7 +5,7 @@ load test_helper
 @test "Rejects commits with prohibited patterns in changeset" {
   repo_run install.sh
   setup_bad_repo
-  repo_run git-secrets install -d $TEST_REPO
+  repo_run git-secrets --install -d $TEST_REPO
   cd $TEST_REPO
   run git commit -m 'Contents are bad not the message'
   [ $status -eq 1 ]
@@ -18,7 +18,7 @@ load test_helper
 @test "Allows commits that do not match prohibited patterns" {
   repo_run install.sh
   setup_good_repo
-  repo_run git-secrets install -d $TEST_REPO
+  repo_run git-secrets --install -d $TEST_REPO
   cd $TEST_REPO
   run git commit -m 'This is fine'
   [ $status -eq 0 ]

--- a/test/prepare-commit-msg.bats
+++ b/test/prepare-commit-msg.bats
@@ -5,7 +5,7 @@ load test_helper
 @test "Rejects merges with prohibited patterns in history" {
   setup_good_repo
   repo_run install.sh
-  repo_run git-secrets install -d $TEST_REPO
+  repo_run git-secrets --install -d $TEST_REPO
   cd $TEST_REPO
   git commit -m 'OK'
   git checkout -b feature
@@ -27,7 +27,7 @@ load test_helper
   setup_good_repo
   repo_run install.sh
   cd $TEST_REPO
-  repo_run git-secrets install
+  repo_run git-secrets --install
   git commit -m 'OK'
   git checkout -b feature
   echo 'Not bad' > data.txt

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -43,3 +43,4 @@ repo_run() {
   shift
   run "${BATS_TEST_DIRNAME}/../${cmd}" $@
 }
+


### PR DESCRIPTION
This commit updates git-secrets to be more like other git subcommands.
Most git subcommands use options ("--option") when subcommands need
subcommands. In the case of git-secrets, we have --scan and --install.
The tool has now been refactored to accept the command as the first
option.

Other added features:
- You can now scan multiple files: git secrets scan path/to/files/*
- Now installs a readme
