### PR TITLE
Use xargs command for grep

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -53,7 +53,7 @@ scan() {
   local allowed=$(git config --get-all secrets.allowed)
   [ -z "${patterns}" ] && return 0
   [ "${RECURSIVE}" -eq 1 ] && action="recurse"
-  output=$(GREP_OPTIONS= LC_ALL=C grep -d $action -nwHE "${patterns}" $files)
+  output=$(GREP_OPTIONS= LC_ALL=C echo $files | xargs -n 100 grep -d $action -nwHE "${patterns}")
   local status=$?
   case "$status" in
     0)

--- a/git-secrets
+++ b/git-secrets
@@ -53,7 +53,11 @@ scan() {
   local allowed=$(git config --get-all secrets.allowed)
   [ -z "${patterns}" ] && return 0
   [ "${RECURSIVE}" -eq 1 ] && action="recurse"
-  output=$(GREP_OPTIONS= LC_ALL=C echo $files | xargs -n 100 grep -d $action -nwHE "${patterns}")
+  if [ "${files}" == "-" ]; then
+    output=$(GREP_OPTIONS= LC_ALL=C grep -d $action -nwHE "${patterns}" $files)
+  else
+    output=$(GREP_OPTIONS= LC_ALL=C echo $files | xargs -n 100 grep -d $action -nwHE "${patterns}")
+  fi
   local status=$?
   case "$status" in
     0)


### PR DESCRIPTION
Hello, @mtdowling.

This pull request for the Issue #6.
I think that problem is solved by using `xargs` and `-n` option.

Quote from the `xargs` man.

> -n number
> Set the maximum number of arguments taken from standard input for each invocation of utility.

How is it?