### PR TITLE
Using `git grep` when scanning with no provided file.

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -52,8 +52,13 @@ scan() {
   local files="$1" action='skip' patterns=$(load_patterns)
   local allowed=$(git config --get-all secrets.allowed)
   [ -z "${patterns}" ] && return 0
-  [ "${RECURSIVE}" -eq 1 ] && action="recurse"
-  output=$(GREP_OPTIONS= LC_ALL=C grep -d $action -nwHE "${patterns}" $files)
+  if [ -z "${files}" ]; then
+    output=$(GREP_OPTIONS= LC_ALL=C git grep -nwHE "${patterns}")
+  else
+    # -r only applies when file paths are provided.
+    [ "${RECURSIVE}" -eq 1 ] && action="recurse"
+    output=$(GREP_OPTIONS= LC_ALL=C grep -d $action -nwHE "${patterns}" $files)
+  fi
   local status=$?
   case "$status" in
     0)
@@ -198,13 +203,7 @@ case "${COMMAND}" in
       add_config "secrets.patterns" "$1"
     fi
     ;;
-  --scan)
-    if [ $# -eq 0 ]; then
-      scan_or_die "$(git ls-files)"
-    else
-      scan_or_die "$@"
-    fi
-    ;;
+  --scan) scan_or_die "$@" ;;
   --list)
     if [ "${GLOBAL}" -eq 1 ]; then
       git config --global --get-regex secrets.*


### PR DESCRIPTION
As an alternative to using xargs, we'll use `git grep` to grep the files
present in a repository. This allows us to quickly scan files in the
repo and properly work with files that contain spaces in the name.

Closes #5
Closes #6
Closes #7 

/@jeskew