### PR TITLE
added possibility to filter false positives by using a .gitallowed file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -354,6 +354,9 @@ regular expression patterns as false positives using the following command:
 
     git secrets --add --allowed 'my regex pattern'
 
+You can also add regular expressions patterns to filter false positives to a 
+.gitallowed file located in the repository's root directory.
+
 First, git-secrets will extract all lines from a file that contain a prohibited
 match. Included in the matched results will be the full path to the name of
 the file that was matched, followed ':', followed by the line number that was

--- a/git-secrets
+++ b/git-secrets
@@ -51,9 +51,17 @@ load_patterns() {
   done
 }
 
+load_allowed() {
+  git config --get-all secrets.allowed
+  local gitallowed="$(git rev-parse --show-toplevel)/.gitallowed"
+  if [ -e "$gitallowed" ]; then
+    cat $gitallowed
+  fi
+}
+
 scan() {
   local files="$1" action='skip' patterns=$(load_patterns)
-  local allowed=$(git config --get-all secrets.allowed)
+  local allowed=$(load_allowed)
   # No need to scan anything if there are no prohibited patterns.
   [ -z "${patterns}" ] && return 0
   # Build up the options to use when scanning with git-grep.
@@ -90,8 +98,10 @@ scan_or_die() {
   echo
   echo "Possible mitigations:"
   echo "- Mark false positives as allowed using: git config --add secrets.allowed ..."
+  echo "- Mark false positives as allowed by adding regular expressions to .gitallowed at repository's root directory"
   echo "- List your configured patterns: git config --get-all secrets.patterns"
   echo "- List your configured allowed patterns: git config --get-all secrets.allowed"
+  echo "- List your configured allowed patterns in .gitallowed at repository's root directory"
   echo "- Use --no-verify if this is a one-time false positive"
   exit 1
 }

--- a/git-secrets.1
+++ b/git-secrets.1
@@ -527,6 +527,9 @@ git secrets \-\-add \-\-allowed \(aqmy regex pattern\(aq
 .UNINDENT
 .UNINDENT
 .sp
+You can also add regular expressions patterns to filter false positives to a
+.gitallowed file located in the repository\(aqs root directory.
+.sp
 First, git\-secrets will extract all lines from a file that contain a prohibited
 match. Included in the matched results will be the full path to the name of
 the file that was matched, followed \(aq:\(aq, followed by the line number that was

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -202,6 +202,22 @@ load test_helper
   echo "$output" | grep -F 'secrets.allowed testing\+abc'
 }
 
+@test "Scans all files and allowing none of the bad patterns in .gitallowed" {
+  setup_bad_repo
+  echo 'hello' > $TEST_REPO/.gitallowed
+  repo_run git-secrets --scan
+  [ $status -eq 1 ]
+}
+
+@test "Scans all files and allowing all bad patterns in .gitallowed" {
+  setup_bad_repo
+  echo '@todo' > $TEST_REPO/.gitallowed
+  echo 'forbidden' >> $TEST_REPO/.gitallowed
+  echo 'me' >> $TEST_REPO/.gitallowed
+  repo_run git-secrets --scan
+  [ $status -eq 0 ]
+}
+
 @test "Adds common AWS patterns" {
   repo_run git config --unset-all secrets
   repo_run git-secrets --register-aws


### PR DESCRIPTION
Added possibility to filter false positives by using a .gitallowed file located in the repository's root directory. This allows you to configure filters for false positives per repository and share them with your team members easily.