### PR TITLE
using combined patterns for git-grep to improve performance

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -104,9 +104,9 @@ scan_history() {
 # Note: this function returns 1 on success, 0 on error.
 git_grep() {
   local options="$1"; shift
-  local files=$@ patterns=$(load_patterns)
-  [ -z "${patterns}" ] && return 1
-  GREP_OPTIONS= LC_ALL=C git grep -nwHE ${options} "${patterns}" $@
+  local files=$@ combined_patterns=$(load_combined_patterns)
+  [ -z "${combined_patterns}" ] && return 1
+  GREP_OPTIONS= LC_ALL=C git grep -nwHE ${options} "${combined_patterns}" $@
 }
 
 # Performs a regular grep, taking into account patterns and recursion.


### PR DESCRIPTION
Unfortunately scan_history is extremely slow when scanning repositories with a lot of pattern matches. After investigating this issue we found out, that the handover of patterns to git-grep does not work as expected. The number of revisions with pattern matches and the number of patterns are affecting the performance negativly. This PR is a workaround for that problem.

The following script helps to setup an environment to run some performance tests.

```
#!/bin/bash
for i in {1..100}
do
  for j in {1..100}
  do
    head -c 1000 /dev/urandom | base64 > $j.txt
    git add $j.txt
    git commit -m "${i}-${j}" --no-verify
  done
done
​
for i in {1..100}
do
  git config --add secrets.patterns "[B-Z0-9]{20}"
done
```

We did a performance test with `git secrets --scan-history` before and after the changes included in this PR.

Before: 37m19.848s
After: 1m22.409s