### PR TITLE
exclude binary files

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -106,7 +106,7 @@ git_grep() {
   local options="$1"; shift
   local files=$@ combined_patterns=$(load_combined_patterns)
   [ -z "${combined_patterns}" ] && return 1
-  GREP_OPTIONS= LC_ALL=C git grep -nwHE ${options} "${combined_patterns}" $@
+  GREP_OPTIONS= LC_ALL=C git grep -nwHEI ${options} "${combined_patterns}" $@
 }
 
 # Performs a regular grep, taking into account patterns and recursion.
@@ -115,7 +115,7 @@ regular_grep() {
   local files=$@ patterns=$(load_patterns) action='skip'
   [ -z "${patterns}" ] && return 1
   [ "${RECURSIVE}" -eq 1 ] && action="recurse"
-  GREP_OPTIONS= LC_ALL=C grep -d "${action}" -nwHE "${patterns}" $@
+  GREP_OPTIONS= LC_ALL=C grep -d "${action}" -nwHEI "${patterns}" $@
 }
 
 # Process the given status ($1) and output variables ($2).


### PR DESCRIPTION
Follow up to https://github.com/awslabs/git-secrets/pull/20. Scanning binary files like images doesn't make too much sense. So I excluded all binary files. What do you think?