### PR TITLE
fixing broken parameter validation

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -295,9 +295,9 @@ done
 
 # Ensure that recursive is not applied with mutually exclusive options.
 if [ "${RECURSIVE}" -eq 1 ]; then
-  if [ "${SCAN_CACHED}" ] \
-      || [ "${SCAN_NO_INDEX}" ] \
-      || [ "${SCAN_UNTRACKED}" ];
+  if [ "${SCAN_CACHED}" -eq 1  ] \
+      || [ "${SCAN_NO_INDEX}" -eq 1 ] \
+      || [ "${SCAN_UNTRACKED}" -eq 1 ];
   then
     die "-r|--recursive cannot be supplied with --cached, --no-index, or --untracked"
   fi

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -289,6 +289,11 @@ load test_helper
   [ $status -eq 1 ]
 }
 
+@test "-recursive is mutual exclusive with --scan" {
+  repo_run git-secrets --scan -r
+  [ $status -eq 0 ]
+}
+
 @test "-recursive can only be used with --scan" {
   repo_run git-secrets --list -r
   [ $status -eq 1 ]


### PR DESCRIPTION
`git secrets --scan -r` always returned 
-r|--recursive cannot be supplied with --cached, --no-index, or --untracked