### PR TITLE
Update all equal statements to use string comparators

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -114,7 +114,7 @@ git_grep() {
 regular_grep() {
   local files=$@ patterns=$(load_patterns) action='skip'
   [ -z "${patterns}" ] && return 1
-  [ "${RECURSIVE}" -eq 1 ] && action="recurse"
+  [ ${RECURSIVE} -eq 1 ] && action="recurse"
   GREP_OPTIONS= LC_ALL=C grep -d "${action}" -nwHEI "${patterns}" $files
 }
 
@@ -208,10 +208,10 @@ install_all_hooks() {
 add_config() {
   local key="$1"; shift
   local value="$@"
-  if [ "${LITERAL}" -eq 1 ]; then
+  if [ ${LITERAL} -eq 1 ]; then
     value=$(sed 's/[\.|$(){}?+*^]/\\&/g' <<< "${value}")
   fi
-  if [ "${GLOBAL}" -eq 1 ]; then
+  if [ ${GLOBAL} -eq 1 ]; then
     git config --global --get-all $key | grep -Fq "${value}" && return 1
     git config --global --add "${key}" "${value}"
   else
@@ -294,10 +294,10 @@ while [ "$#" -ne 0 ]; do
 done
 
 # Ensure that recursive is not applied with mutually exclusive options.
-if [ "${RECURSIVE}" -eq 1 ]; then
-  if [ "${SCAN_CACHED}" -eq 1  ] \
-      || [ "${SCAN_NO_INDEX}" -eq 1 ] \
-      || [ "${SCAN_UNTRACKED}" -eq 1 ];
+if [ ${RECURSIVE} -eq 1 ]; then
+  if [ ${SCAN_CACHED} -eq 1  ] \
+      || [ ${SCAN_NO_INDEX} -eq 1 ] \
+      || [ ${SCAN_UNTRACKED} -eq 1 ];
   then
     die "-r|--recursive cannot be supplied with --cached, --no-index, or --untracked"
   fi
@@ -312,7 +312,7 @@ case "${COMMAND}" in
     ${COMMAND:2} "$@"
     ;;
   --add)
-    if [ "${ALLOWED}" -eq 1 ]; then
+    if [ ${ALLOWED} -eq 1 ]; then
       add_config "secrets.allowed" "$1"
     else
       add_config "secrets.patterns" "$1"
@@ -321,7 +321,7 @@ case "${COMMAND}" in
   --scan) scan_with_fn_or_die "scan" "$@" ;;
   --scan-history) scan_with_fn_or_die "scan_history" "$@" ;;
   --list)
-    if [ "${GLOBAL}" -eq 1 ]; then
+    if [ ${GLOBAL} -eq 1 ]; then
       git config --global --get-regex secrets.*
     else
       git config --get-regex secrets.*

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -289,12 +289,12 @@ load test_helper
   [ $status -eq 1 ]
 }
 
-@test "-recursive is mutual exclusive with --scan" {
+@test "--recursive can be used with --scan" {
   repo_run git-secrets --scan -r
   [ $status -eq 0 ]
 }
 
-@test "-recursive can only be used with --scan" {
+@test "--recursive can't be used with --list" {
   repo_run git-secrets --list -r
   [ $status -eq 1 ]
 }


### PR DESCRIPTION
@mtdowling @michaelwittig

See https://github.com/awslabs/git-secrets/issues/27

The major change here is that I treat all the equal statements as comparing strings and not integers.

The tests still pass but I've renamed two of them.