### PR TITLE
Explicitly set `IFS` when calling provider commands

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -49,7 +49,7 @@ load_patterns() {
   git config --get-all secrets.patterns
   # Execute each provider and use their output to build up patterns
   git config --get-all secrets.providers | while read cmd; do
-    echo "$($cmd)"
+    echo "$(export IFS=$'\n\t '; $cmd)"
   done
 }
 

--- a/test/pre-commit.bats
+++ b/test/pre-commit.bats
@@ -46,3 +46,17 @@ load test_helper
   run git commit -m 'This is also fine'
   [ $status -eq 0 ]
 }
+
+@test "Rejects commits with prohibited patterns in changeset when AWS provider is enabled" {
+  setup_bad_repo
+  repo_run git-secrets --install $TEST_REPO
+  repo_run git-secrets --register-aws $TEST_REPO
+  cd $TEST_REPO
+  run git commit -m 'Contents are bad not the message'
+  [ $status -eq 1 ]
+  echo "${lines}" | grep -vq 'git secrets --aws-provider: command not found'
+
+  [ "${lines[0]}" == "data.txt:1:@todo more stuff" ]
+  [ "${lines[1]}" == "failure1.txt:1:another line... forbidden" ]
+  [ "${lines[2]}" == "failure2.txt:1:me" ]
+}


### PR DESCRIPTION
- add test for error `git secrets --aws-provider: command not found`
  which occurs when space-containing `provider` command is executed

Fixes https://github.com/awslabs/git-secrets/issues/29