### PR TITLE
Fix error in Examples Walkthrough of README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -420,8 +420,8 @@ And the following registered patterns:
 
 ::
 
-    git config --add 'password\s*=\s*.+'
-    git config --add --allowed --literal 'ex@mplepassword'
+    git secrets --add 'password\s*=\s*.+'
+    git secrets --add --allowed --literal 'ex@mplepassword'
 
 Running ``git secrets --scan /tmp/example``, the result will
 result in the following error output::


### PR DESCRIPTION
On lines 423 and 424 of README.rst the example uses `git config` when
it should actually be `git secrets`.

Note: 
I did not see a "contributing" guideline for this repository so I'm just winging it. If I'm going about this the wrong way (perhaps I should have made an issue?) please let me know/close this pull request unmerged. Thanks!