### PR TITLE
Supporting spaces in git exec path

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -43,7 +43,7 @@ pre_commit_hook* pre-commit hook (internal only)
 prepare_commit_msg_hook* prepare-commit-msg hook (internal only)"
 
 # Include the git setup script. This parses and normalized CLI arguments.
-. $(git --exec-path)/git-sh-setup
+. "$(git --exec-path)"/git-sh-setup
 
 load_patterns() {
   git config --get-all secrets.patterns


### PR DESCRIPTION
In Windows e.g. in GitBash, Git can be installed with spaces in the path.  This fix stops git-secrets failing with this error:
`git-secrets: line 46: C:\Program: No such file or directory`