### PR TITLE
Fix for windows bash: Updated git-secrets script to handle carriage returns

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -52,7 +52,7 @@ load_patterns() {
     local result="$(export IFS=$'\n\t '; $cmd)"
     # Do not add empty lines from providers as that would match everything.
     if [ -n "${result}" ]; then
-      echo "$result"
+      echo "$result" | tr -d "\r"
     fi
   done
 }


### PR DESCRIPTION
 Git-secrets script will now ignore new lines (including carriage returns from Windows). This fix should work for Windows 10 Bash, Windows Git Bash, Windows command-line, and linux (I haven't tested this fix thoroughly on an actual linux machine).

This should fix [issue 43](https://github.com/awslabs/git-secrets/issues/43)