### PR TITLE
Docker build shell test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
   - env: BASH_VER=4.0
   - env: GIT_VER=1:2.7.4-0ubuntu1 BASH_VER=4.0
   - env: GIT_VER=1:1.9.1-1ubuntu0.6 BASH_VER=4.0
-
   allow_failures:
   - env: GIT_VER=1:2.7.4-0ubuntu1 BASH_VER=3.0
   - env: GIT_VER=1:1.9.1-1ubuntu0.6 BASH_VER=3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ before_install:
 
 matrix:
   include:
-  - env: GIT_VER=1.8.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.9.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=2.0.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   allow_failures:
-  - env: GIT_VER=1.8.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.9.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=2.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+services:
+  - docker
+
 language: bash
 
 before_install:
@@ -6,3 +9,11 @@ before_install:
 
 script:
 - make test
+- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=4.0' ubuntu /run.sh
+- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=4.0' ubuntu:14.04 /run.sh
+- docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh
+
+after_script:
+- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=3.0' ubuntu /run.sh
+- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=3.0' ubuntu:14.04 /run.sh
+- docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,12 @@ before_install:
 matrix:
   include:
   - env: BASH_VER=4.0
-  - env: GIT_VER=1:2.7.4-0ubuntu1
-    env: BASH_VER=4.0
-  - env: GIT_VER=1:1.9.1-1ubuntu0.6
-    env: BASH_VER=4.0
+  - env: GIT_VER=1:2.7.4-0ubuntu1 BASH_VER=4.0
+  - env: GIT_VER=1:1.9.1-1ubuntu0.6 BASH_VER=4.0
 
   allow_failures:
-  - env: GIT_VER=1:2.7.4-0ubuntu1
-    env: BASH_VER=3.0
-  - env: GIT_VER=1:1.9.1-1ubuntu0.6
-    env: BASH_VER=3.0
+  - env: GIT_VER=1:2.7.4-0ubuntu1 BASH_VER=3.0
+  - env: GIT_VER=1:1.9.1-1ubuntu0.6 BASH_VER=3.0
 
 script:
 - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ before_install:
 script:
 - make test
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=4.0' ubuntu /run.sh
-- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=4.0' ubuntu:14.04 /run.sh
+- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.5' -e 'BASH_VER=4.0' ubuntu:14.04 /run.sh
 - docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh
 
 after_script:
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=3.0' ubuntu /run.sh
-- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=3.0' ubuntu:14.04 /run.sh
+- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.5' -e 'BASH_VER=3.0' ubuntu:14.04 /run.sh
 - docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 services:
   - docker
 
@@ -9,13 +10,19 @@ before_install:
 
 matrix:
   include:
-  - env: GIT_VER=1.9.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
-  - env: GIT_VER=2.0.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=1.9.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=2.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.9.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=2.0.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.9.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=centos:centos7
+  - env: GIT_VER=2.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=centos:centos7
+  - env: GIT_VER=1.9.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=centos:centos7
+  - env: GIT_VER=2.0.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=centos:centos7
   allow_failures:
   - env: GIT_VER=1.9.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=2.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.9.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=centos:centos7
+  - env: GIT_VER=2.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=centos:centos7
   fast_finish: true
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ script:
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=4.0' ubuntu /run.sh
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.5' -e 'BASH_VER=4.0' ubuntu:14.04 /run.sh
 - docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh
+- docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh
+
+allow_failures:
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=3.0' ubuntu /run.sh
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.5' -e 'BASH_VER=3.0' ubuntu:14.04 /run.sh
-- docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ before_install:
 
 matrix:
   include:
-  - env: GIT_VER=1.8.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.9.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=2.0.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
-  - env: GIT_VER=1.8.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.9.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=2.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   allow_failures:
-  - env: GIT_VER=1.8.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.9.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=2.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ script:
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=4.0' ubuntu /run.sh
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.5' -e 'BASH_VER=4.0' ubuntu:14.04 /run.sh
 - docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh
-
-after_script:
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=3.0' ubuntu /run.sh
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.5' -e 'BASH_VER=3.0' ubuntu:14.04 /run.sh
 - docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ before_install:
 
 matrix:
   include:
-  - env: GIT_VER=1.0.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.8.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=2.0.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   allow_failures:
-  - env: GIT_VER=1.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.8.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=2.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-
 services:
   - docker
 
@@ -8,13 +7,18 @@ before_install:
 - git config --global user.email "awslabs@amazon.com"
 - git config --global user.name "Awslabs"
 
+env:
+
 matrix:
   include:
-  - env: GIT_VER=1.9.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.8.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=2.0.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
-  allow_failures:
-  - env: GIT_VER=1.9.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=1.8.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   - env: GIT_VER=2.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  allow_failures:
+  - env: GIT_VER=1.8.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=2.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  fast_finish: true
 
 script:
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e "GIT_VER=$GIT_VER" -e "BASH_VER=$BASH_VER" $DOCKER_BUILD_IMAGE /run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 services:
   - docker
 
@@ -9,12 +10,11 @@ before_install:
 
 matrix:
   include:
-  - env: BASH_VER=4.0
-  - env: GIT_VER=1:2.7.4-0ubuntu1 BASH_VER=4.0
-  - env: GIT_VER=1:1.9.1-1ubuntu0.6 BASH_VER=4.0
+  - env: GIT_VER=1.0.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=2.0.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
   allow_failures:
-  - env: GIT_VER=1:2.7.4-0ubuntu1 BASH_VER=3.0
-  - env: GIT_VER=1:1.9.1-1ubuntu0.6 BASH_VER=3.0
+  - env: GIT_VER=1.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
+  - env: GIT_VER=2.0.0 BASH_VER=3.0 DOCKER_BUILD_IMAGE=ubuntu:14.04
 
 script:
-- docker run -it  -v $PWD/docker-run.sh:/run.sh -e "GIT_VER=$GIT_VER" -e "BASH_VER=$BASH_VER" ubuntu:14.04 /run.sh
+- docker run -it  -v $PWD/docker-run.sh:/run.sh -e "GIT_VER=$GIT_VER" -e "BASH_VER=$BASH_VER" $DOCKER_BUILD_IMAGE /run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ matrix:
 
 script:
 - make test
-- docker run -it  -v $PWD/docker-run.sh:/run.sh ubuntu /run.sh
+- docker run -it  -v $PWD/docker-run.sh:/run.sh -e "GIT_VER=$GIT_VER" -e "BASH_VER=$BASH_VER" ubuntu /run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,23 @@ services:
 language: bash
 
 before_install:
-- git config --global user.email "you@example.com"
-- git config --global user.name "Your Name"
+- git config --global user.email "awslabs@amazon.com"
+- git config --global user.name "Awslabs"
+
+matrix:
+  include:
+  - env: BASH_VER=4.0
+  - env: GIT_VER=1:2.7.4-0ubuntu1
+    env: BASH_VER=4.0
+  - env: GIT_VER=1:1.9.1-1ubuntu0.6
+    env: BASH_VER=4.0
+
+  allow_failures:
+  - env: GIT_VER=1:2.7.4-0ubuntu1
+    env: BASH_VER=3.0
+  - env: GIT_VER=1:1.9.1-1ubuntu0.6
+    env: BASH_VER=3.0
 
 script:
 - make test
-- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=4.0' ubuntu /run.sh
-- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.6' -e 'BASH_VER=4.0' ubuntu:14.04 /run.sh
-- docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh
-- docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh
-
-allow_failures:
-- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=3.0' ubuntu /run.sh
-- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.6' -e 'BASH_VER=3.0' ubuntu:14.04 /run.sh
+- docker run -it  -v $PWD/docker-run.sh:/run.sh ubuntu /run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,4 @@ matrix:
   - env: GIT_VER=1:1.9.1-1ubuntu0.6 BASH_VER=3.0
 
 script:
-- make test
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e "GIT_VER=$GIT_VER" -e "BASH_VER=$BASH_VER" ubuntu /run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ before_install:
 script:
 - make test
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=4.0' ubuntu /run.sh
-- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.5' -e 'BASH_VER=4.0' ubuntu:14.04 /run.sh
+- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.6' -e 'BASH_VER=4.0' ubuntu:14.04 /run.sh
 - docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh
 - docker run -it -v $PWD/docker-run.sh:/run.sh -e 'BASH_VER=4.0' centos /run.sh
 
 allow_failures:
 - docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:2.7.4-0ubuntu1' -e 'BASH_VER=3.0' ubuntu /run.sh
-- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.5' -e 'BASH_VER=3.0' ubuntu:14.04 /run.sh
+- docker run -it  -v $PWD/docker-run.sh:/run.sh -e 'GIT_VER=1:1.9.1-1ubuntu0.6' -e 'BASH_VER=3.0' ubuntu:14.04 /run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ before_install:
 - git config --global user.email "awslabs@amazon.com"
 - git config --global user.name "Awslabs"
 
-env:
-
 matrix:
   include:
   - env: GIT_VER=1.8.0 BASH_VER=4.0 DOCKER_BUILD_IMAGE=ubuntu:14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ matrix:
   - env: GIT_VER=1:1.9.1-1ubuntu0.6 BASH_VER=3.0
 
 script:
-- docker run -it  -v $PWD/docker-run.sh:/run.sh -e "GIT_VER=$GIT_VER" -e "BASH_VER=$BASH_VER" ubuntu /run.sh
+- docker run -it  -v $PWD/docker-run.sh:/run.sh -e "GIT_VER=$GIT_VER" -e "BASH_VER=$BASH_VER" ubuntu:14.04 /run.sh

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -2,11 +2,17 @@
 
 set -e
 
+GIT_CMD="git"
+
+if [ -z ${GIT_VER+x} ]; then
+    GIT_CMD='git='$GIT_VER
+fi
+
 if [ -f /etc/debian_version ]; then
     echo "Updating apt-get"
     apt-get -qq -y update
-    echo "Installing gcc wget make git=$GIT_VER"
-    apt-get -y install gcc wget make git=$GIT_VER > /dev/null
+    echo "Installing gcc wget make $GIT_CMD"
+    apt-get -y install gcc wget make $GIT_CMD > /dev/null
 elif [ -f /etc/redhat-release ]; then
     echo "Updating yum"
     yum -q -y update
@@ -25,6 +31,7 @@ cd bash-$BASH_VER
 make -s
 make -s install
 
+cd /
 # Clone git-secrets, install and run tests.
 git clone https://github.com/awslabs/git-secrets.git
 cd git-secrets

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -3,26 +3,29 @@
 set -e
 
 if [ -f /etc/debian_version ]; then
-    apt-get -y update
-    apt-get -y install gcc wget
-    apt-get -y install make git=$GIT_VER
+    apt-get -y -q update
+    echo "Installing gcc wget make git=$GIT_VER"
+    apt-get -y -qq install gcc wget make git=$GIT_VER
 elif [ -f /etc/redhat-release ]; then
-    yum -y update
-    yum -y install make git gcc wget
+    echo "Updating yum"
+    yum -y -q update
+    echo "Installing gcc wget make git"
+    yum -y -q install make git gcc wget
 fi
 
 wget https://ftp.gnu.org/gnu/bash/bash-$BASH_VER.tar.gz
-tar -xvf bash*
+tar -zxf bash-$BASH_VER.tar.gz
 cd bash-$BASH_VER
 ./configure --prefix=/usr \
     --bindir=/bin \
     --without-bash-malloc \
-    --with-installed-readline
-make
-make install
+    --with-installed-readline \
+    --quiet
+make -s
+make -s install
 
 # Clone git-secrets, install and run tests.
 git clone https://github.com/awslabs/git-secrets.git
 cd git-secrets
-make install
-make test
+make -s install
+make -s test

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -14,7 +14,8 @@ elif [ -f /etc/redhat-release ]; then
     echo "Updating yum"
     yum -q -y update
     echo "Installing make gcc wget epel-release dnf"
-    yum -y install make gcc wget epel-release dnf > /dev/null
+    yum -y install make gcc wget epel-release > /dev/null
+    yum -y install dnf > /dev/null
     echo "Installing dh-autoreconf curl-devel expat-devel gettext-devel openssl-devel perl-devel zlib-devel"
     dnf -y install dh-autoreconf curl-devel expat-devel gettext-devel openssl-devel perl-devel zlib-devel > /dev/null
     ln -s /usr/bin/db2x_docbook2texi /usr/bin/docbook2x-texi

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -3,14 +3,15 @@
 set -e
 
 if [ -f /etc/debian_version ]; then
-    apt-get -y -q update
+    echo "Updating apt-get"
+    apt-get -qq -y update
     echo "Installing gcc wget make git=$GIT_VER"
-    apt-get -y -qq install gcc wget make git=$GIT_VER
+    apt-get -y install gcc wget make git=$GIT_VER > /dev/null
 elif [ -f /etc/redhat-release ]; then
     echo "Updating yum"
-    yum -y -q update
+    yum -q -y update
     echo "Installing gcc wget make git"
-    yum -y -q install make git gcc wget
+    yum -y install make git gcc wget > /dev/null
 fi
 
 wget https://ftp.gnu.org/gnu/bash/bash-$BASH_VER.tar.gz

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -f /etc/debian_version ]; then
+    apt-get -y update
+    apt-get -y install gcc wget
+    apt-get -y install make git=$GIT_VER
+elif [ -f /etc/redhat-release ]; then
+    yum -y update
+    yum -y install make git gcc wget
+fi
+
+wget https://ftp.gnu.org/gnu/bash/bash-$BASH_VER.tar.gz
+tar -xvf bash*
+cd bash-$BASH_VER
+./configure --prefix=/usr \
+    --bindir=/bin \
+    --without-bash-malloc \
+    --with-installed-readline
+make
+make install
+
+# Clone git-secrets, install and run tests.
+git clone https://github.com/awslabs/git-secrets.git
+cd git-secrets
+make install
+make test

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -7,18 +7,21 @@ if [ -f /etc/debian_version ]; then
     apt-get -qq -y update
     echo "Installing gcc wget make"
     apt-get -y install gcc wget make > /dev/null
-    apt-get -y install dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev
+    echo "Installing dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev"
+    apt-get -y install dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev > /dev/null
 
 elif [ -f /etc/redhat-release ]; then
     echo "Updating yum"
     yum -q -y update
-    echo "Installing gcc wget make"
-    dnf -y install dh-autoreconf curl-devel expat-devel gettext-devel openssl-devel perl-devel zlib-devel
-    yum -y install make gcc wget > /dev/null
+    echo "Installing make gcc wget epel-release dnf"
+    yum -y install make gcc wget epel-release dnf > /dev/null
+    echo "Installing dh-autoreconf curl-devel expat-devel gettext-devel openssl-devel perl-devel zlib-devel"
+    dnf -y install dh-autoreconf curl-devel expat-devel gettext-devel openssl-devel perl-devel zlib-devel > /dev/null
     ln -s /usr/bin/db2x_docbook2texi /usr/bin/docbook2x-texi
 fi
 
 # Install git from source
+echo "Downloading git $GIT_VER and building from source"
 wget https://www.kernel.org/pub/software/scm/git/git-$GIT_VER.tar.gz
 tar -zxf git-$GIT_VER.tar.gz
 cd git-$GIT_VER
@@ -28,6 +31,8 @@ make -s all
 make -s install 
 
 # Install bash from source
+echo "Downloading bash $BASH_VER and building from source"
+cd /
 wget https://ftp.gnu.org/gnu/bash/bash-$BASH_VER.tar.gz
 tar -zxf bash-$BASH_VER.tar.gz
 cd bash-$BASH_VER
@@ -39,8 +44,8 @@ cd bash-$BASH_VER
 make -s
 make -s install
 
-cd /
 # Clone git-secrets, install and run tests.
+cd /
 git clone https://github.com/awslabs/git-secrets.git
 cd git-secrets
 make -s install

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -11,15 +11,29 @@ fi
 if [ -f /etc/debian_version ]; then
     echo "Updating apt-get"
     apt-get -qq -y update
-    echo "Installing gcc wget make $GIT_CMD"
-    apt-get -y install gcc wget make $GIT_CMD > /dev/null
+    echo "Installing gcc wget make"
+    apt-get -y install gcc wget make > /dev/null
+    apt-get -y install dh-autoreconf libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev
+
 elif [ -f /etc/redhat-release ]; then
     echo "Updating yum"
     yum -q -y update
-    echo "Installing gcc wget make git"
-    yum -y install make git gcc wget > /dev/null
+    echo "Installing gcc wget make"
+    dnf -y install dh-autoreconf curl-devel expat-devel gettext-devel openssl-devel perl-devel zlib-devel
+    yum -y install make gcc wget > /dev/null
+    ln -s /usr/bin/db2x_docbook2texi /usr/bin/docbook2x-texi
 fi
 
+# Install git from source
+wget https://www.kernel.org/pub/software/scm/git/git-$GIT_VER.tar.gz
+tar -zxf git-$GIT_VER.tar.gz
+cd git-$GIT_VER
+make -s configure
+./configure --prefix=/usr --quiet
+make -s all
+make -s install 
+
+# Install bash from source
 wget https://ftp.gnu.org/gnu/bash/bash-$BASH_VER.tar.gz
 tar -zxf bash-$BASH_VER.tar.gz
 cd bash-$BASH_VER

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-if [ -z ${GIT_VER+x} ]; then
-    GIT_CMD="git"
-else
-    GIT_CMD="git=$GIT_VER"
-fi
-
 if [ -f /etc/debian_version ]; then
     echo "Updating apt-get"
     apt-get -qq -y update

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-GIT_CMD="git"
-
 if [ -z ${GIT_VER+x} ]; then
-    GIT_CMD='git='$GIT_VER
+    GIT_CMD="git"
+else
+    GIT_CMD="git=$GIT_VER"
 fi
 
 if [ -f /etc/debian_version ]; then


### PR DESCRIPTION
The build will fail for bash v3.0.0 as the dependency `bats` fails in bash 3.0.0
