### PR TITLE
AWS keys all start with "AKIA" - amended the regexps accordingly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ Each of these options must appear first on the command line.
     in ``~/.aws/credentials`` are not found in any commit. The following
     checks are added:
 
-    - AWS Access Key ID via ``[A-Z0-9]{20}``
+    - AWS Access Key ID via ``AKAI[A-Z0-9]{16}``
     - AWS Secret Access Key assignments via ":" or "=" surrounded by optional
       quotes
     - AWS account ID assignments via ":" or "=" surrounded by optional quotes
@@ -283,11 +283,11 @@ Examples
 
 Adds a prohibited pattern to the current repo::
 
-    git secrets --add '[A-Z0-9]{20}'
+    git secrets --add 'AKAI[A-Z0-9]{16}'
 
 Adds a prohibited pattern to the global git config::
 
-    git secrets --add --global '[A-Z0-9]{20}'
+    git secrets --add --global 'AKAI[A-Z0-9]{16}'
 
 Adds a string that is scanned for literally (``+`` is escaped)::
 
@@ -362,7 +362,7 @@ regular expression patterns as false positives using the following command:
 
     git secrets --add --allowed 'my regex pattern'
 
-You can also add regular expressions patterns to filter false positives to a 
+You can also add regular expressions patterns to filter false positives to a
 .gitallowed file located in the repository's root directory. Lines starting
 with # are skipped (comment line) and empty lines are also skipped.
 

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ Each of these options must appear first on the command line.
     in ``~/.aws/credentials`` are not found in any commit. The following
     checks are added:
 
-    - AWS Access Key ID via ``AKAI[A-Z0-9]{16}``
+    - AWS Access Key ID via ``AKIA[A-Z0-9]{16}``
     - AWS Secret Access Key assignments via ":" or "=" surrounded by optional
       quotes
     - AWS account ID assignments via ":" or "=" surrounded by optional quotes
@@ -283,11 +283,11 @@ Examples
 
 Adds a prohibited pattern to the current repo::
 
-    git secrets --add 'AKAI[A-Z0-9]{16}'
+    git secrets --add 'AKIA[A-Z0-9]{16}'
 
 Adds a prohibited pattern to the global git config::
 
-    git secrets --add --global 'AKAI[A-Z0-9]{16}'
+    git secrets --add --global 'AKIA[A-Z0-9]{16}'
 
 Adds a string that is scanned for literally (``+`` is escaped)::
 

--- a/git-secrets
+++ b/git-secrets
@@ -231,7 +231,7 @@ register_aws() {
   local aws="(AWS|aws|Aws)?_?" quote="(\"|')" connect="\s*(:|=>|=)\s*"
   local opt_quote="${quote}?"
   add_config 'secrets.providers' 'git secrets --aws-provider'
-  add_config 'secrets.patterns' '[A-Z0-9]{20}'
+  add_config 'secrets.patterns' 'AKAI[A-Z0-9]{16}'
   add_config 'secrets.patterns' "${opt_quote}${aws}(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)${opt_quote}${connect}${opt_quote}[A-Za-z0-9/\+=]{40}${opt_quote}"
   add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'

--- a/git-secrets
+++ b/git-secrets
@@ -231,7 +231,7 @@ register_aws() {
   local aws="(AWS|aws|Aws)?_?" quote="(\"|')" connect="\s*(:|=>|=)\s*"
   local opt_quote="${quote}?"
   add_config 'secrets.providers' 'git secrets --aws-provider'
-  add_config 'secrets.patterns' 'AKAI[A-Z0-9]{16}'
+  add_config 'secrets.patterns' 'AKIA[A-Z0-9]{16}'
   add_config 'secrets.patterns' "${opt_quote}${aws}(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)${opt_quote}${connect}${opt_quote}[A-Za-z0-9/\+=]{40}${opt_quote}"
   add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -278,7 +278,7 @@ load test_helper
   repo_run git-secrets --register-aws
   git config --local --get secrets.providers
   repo_run git-secrets --list
-  echo "$output" | grep -F '[A-Z0-9]{20}'
+  echo "$output" | grep -F 'AKAI[A-Z0-9]{16}'
   echo "$output" | grep "AKIAIOSFODNN7EXAMPLE"
   echo "$output" | grep "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 }

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -278,7 +278,7 @@ load test_helper
   repo_run git-secrets --register-aws
   git config --local --get secrets.providers
   repo_run git-secrets --list
-  echo "$output" | grep -F 'AKAI[A-Z0-9]{16}'
+  echo "$output" | grep -F 'AKIA[A-Z0-9]{16}'
   echo "$output" | grep "AKIAIOSFODNN7EXAMPLE"
   echo "$output" | grep "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 }


### PR DESCRIPTION
Amend the AWS key regexp throughout, as keys all start with "AKIA" - should reduce false positives.