### PR TITLE
Add advance configuration section to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,45 @@ on each commit::
 
 
 
+
+Advanced configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+Add a configuration template if you want to add hooks to all repositories you
+initialize or clone in the future.
+
+::
+
+    git secrets --register-aws --global
+
+
+Add hooks to all your local repositories.
+
+::
+
+    git secrets --install ~/.git-templates/git-secrets
+    git config --global init.templateDir ~/.git-templates/git-secrets
+
+
+Add custom providers to scan for security credentials.
+
+::
+
+    git secrets --add-provider -- cat /path/to/secret/file/patterns
+
+
+Before making public a repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With git-secrets is also possible to scan a repository including all revisions:
+
+::
+
+    git secrets --scan-history
+
+
+
+
 Options
 -------
 


### PR DESCRIPTION
The advanced configuration section in this wonderful article made me realize the power of git-secrets: http://ebi-cloud-portal.readthedocs.io/en/latest/securing_credentials.html#advanced-configuration

I think it would be beneficial to add this information to the readme.