### PR TITLE
Add exit code to register_aws

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -236,6 +236,12 @@ register_aws() {
   add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'
   add_config 'secrets.allowed' "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+  if [[ $? == 0 ]]; then
+    echo 'OK'
+  fi
+
+  exit $?
 }
 
 aws_provider() {


### PR DESCRIPTION
Issue #73

Add exit code to `register_aws`. If the function is succeeded, it returns `OK`. 
Otherwise, it returns an error.
