### PR TITLE
Aws doc updates

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -234,8 +234,41 @@ register_aws() {
   add_config 'secrets.patterns' '[A-Z0-9]{20}'
   add_config 'secrets.patterns' "${opt_quote}${aws}(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)${opt_quote}${connect}${opt_quote}[A-Za-z0-9/\+=]{40}${opt_quote}"
   add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
+  # Fictitious passwords and account IDs found in AWS documentation
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'
   add_config 'secrets.allowed' "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'
+  add_config 'secrets.allowed' 'AKIAI44QH8DHBEXAMPLE'
+  add_config 'secrets.allowed' "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  add_config 'secrets.allowed' "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY"
+  add_config 'secrets.allowed' '111122223333'
+  add_config 'secrets.allowed' '1111-2222-3333'
+  add_config 'secrets.allowed' '444455556666'
+  add_config 'secrets.allowed' '4444-5555-6666'
+  add_config 'secrets.allowed' '123456789012'
+  add_config 'secrets.allowed' '1234-5678-9012'
+  add_config 'secrets.allowed' '777788889999'
+  add_config 'secrets.allowed' '7777-8888-9999'
+  add_config 'secrets.allowed' '000000000000'
+  add_config 'secrets.allowed' '0000-0000-0000'
+  add_config 'secrets.allowed' '111111111111'
+  add_config 'secrets.allowed' '1111-1111-1111'
+  add_config 'secrets.allowed' '222222222222'
+  add_config 'secrets.allowed' '2222-2222-2222'
+  add_config 'secrets.allowed' '333333333333'
+  add_config 'secrets.allowed' '3333-3333-3333'
+  add_config 'secrets.allowed' '444444444444'
+  add_config 'secrets.allowed' '4444-4444-4444'
+  add_config 'secrets.allowed' '555555555555'
+  add_config 'secrets.allowed' '5555-5555-5555'
+  add_config 'secrets.allowed' '666666666666'
+  add_config 'secrets.allowed' '6666-6666-6666'
+  add_config 'secrets.allowed' '777777777777'
+  add_config 'secrets.allowed' '7777-7777-7777'
+  add_config 'secrets.allowed' '888888888888'
+  add_config 'secrets.allowed' '8888-8888-8888'
+  add_config 'secrets.allowed' '999999999999'
+  add_config 'secrets.allowed' '9999-9999-9999'
 }
 
 aws_provider() {

--- a/git-secrets
+++ b/git-secrets
@@ -237,7 +237,6 @@ register_aws() {
   # Fictitious passwords and account IDs found in AWS documentation
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'
   add_config 'secrets.allowed' "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-  add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'
   add_config 'secrets.allowed' 'AKIAI44QH8DHBEXAMPLE'
   add_config 'secrets.allowed' "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
   add_config 'secrets.allowed' "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY"


### PR DESCRIPTION
Added several fictitious account IDs, access keys, and secret access keys that are found in AWS documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
