### PR TITLE
Simply Installation on Windows. Update README.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Force the bash scripts to be checked out with LF line endings.
+git-secrets text eol=lf
+git-secrets.1 text eol=lf
+test/bats/bin/* text eol=lf
+test/bats/libexec/* text eol=lf
+*.bats text eol=lf
+*.bash text eol=lf

--- a/README.rst
+++ b/README.rst
@@ -35,15 +35,29 @@ Installing git-secrets
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ``git-secrets`` must be placed somewhere in your PATH so that it is picked up
-by ``git`` when running ``git secrets``. You can use ``install`` target of the
-provided Makefile to install ``git secrets`` and the man page. You can
-customize the install path using the PREFIX and MANPREFIX variables.
+by ``git`` when running ``git secrets``. 
+
+**\*nix (Linux/OSX)**
+
+You can use ``install`` target of the provided Makefile to install 
+``git secrets`` and the man page. You can customize the install path
+using the PREFIX and MANPREFIX variables.
 
 ::
 
     make install
 
-Or, installing with Homebrew (for OS X users).
+**Windows**
+
+Run the provided install.ps1 powershell script. This will copy the needed files
+to an installation directory ("%USERPROFILE%/.git-secrets" by default) and add
+the directory to the current user PATH.
+
+::
+
+    PS > ./install.ps1
+
+**Homebrew (for OS X users).**
 
 ::
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,48 @@
+Param([string]$InstallationDirectory = $($Env:USERPROFILE + "\.git-secrets"))
+
+Write-Host "Checking to see if installation directory already exists..."
+if (-not (Test-Path $InstallationDirectory))
+{
+    Write-Host "Creating installation directory."
+    New-Item -ItemType Directory -Path $InstallationDirectory | Out-Null
+}
+else
+{
+    Write-Host "Installation directory already exists."
+}
+
+Write-Host "Copying files."
+Copy-Item ./git-secrets -Destination $InstallationDirectory -Force
+Copy-Item ./git-secrets.1 -Destination $InstallationDirectory -Force
+
+Write-Host "Checking if directory already exists in Path..."
+$currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+if ($currentPath -notlike "*$InstallationDirectory*")
+{
+    Write-Host "Adding to path."
+    $newPath = $currentPath
+    if(-not ($newPath.EndsWith(";")))
+    {
+        $newPath = $newPath + ";"
+    }
+    $newPath = $newPath + $InstallationDirectory
+    [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+}
+else
+{
+    Write-Host "Already in Path."
+}
+
+# Adding to Session
+Write-Host "Adding to user session."
+$currentSessionPath = $Env:Path
+if ($currentSessionPath -notlike "*$InstallationDirectory*")
+{
+    if(-not ($currentSessionPath.EndsWith(";")))
+    {
+        $currentSessionPath = $currentSessionPath + ";"
+    }
+    $Env:Path = $currentSessionPath + $InstallationDirectory
+}
+
+Write-Host "Done."


### PR DESCRIPTION
*Issue #, if available:*
#83

*Description of changes:*
I added an installation powershell script for use on windows as an alternative to the Makefile. The README was updated to reflect this addition.

I also added a .gitattributes file to ensure the shell scripts were checked out with LF line endings on Windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
