### PR TITLE
Adjust regexp for aws iam resource keys to check for valid prefixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,11 +35,11 @@ Installing git-secrets
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ``git-secrets`` must be placed somewhere in your PATH so that it is picked up
-by ``git`` when running ``git secrets``. 
+by ``git`` when running ``git secrets``.
 
 **\*nix (Linux/OSX)**
 
-You can use ``install`` target of the provided Makefile to install 
+You can use ``install`` target of the provided Makefile to install
 ``git secrets`` and the man page. You can customize the install path
 using the PREFIX and MANPREFIX variables.
 
@@ -161,7 +161,7 @@ Each of these options must appear first on the command line.
     in ``~/.aws/credentials`` are not found in any commit. The following
     checks are added:
 
-    - AWS Access Key ID via ``[A-Z0-9]{20}``
+    - AWS Access Key ID via ``(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}``
     - AWS Secret Access Key assignments via ":" or "=" surrounded by optional
       quotes
     - AWS account ID assignments via ":" or "=" surrounded by optional quotes
@@ -415,7 +415,7 @@ regular expression patterns as false positives using the following command:
 
     git secrets --add --allowed 'my regex pattern'
 
-You can also add regular expressions patterns to filter false positives to a 
+You can also add regular expressions patterns to filter false positives to a
 .gitallowed file located in the repository's root directory. Lines starting
 with # are skipped (comment line) and empty lines are also skipped.
 

--- a/git-secrets
+++ b/git-secrets
@@ -235,7 +235,7 @@ register_aws() {
   local aws="(AWS|aws|Aws)?_?" quote="(\"|')" connect="\s*(:|=>|=)\s*"
   local opt_quote="${quote}?"
   add_config 'secrets.providers' 'git secrets --aws-provider'
-  add_config 'secrets.patterns' '[A-Z0-9]{20}'
+  add_config 'secrets.patterns' '(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'
   add_config 'secrets.patterns' "${opt_quote}${aws}(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)${opt_quote}${connect}${opt_quote}[A-Za-z0-9/\+=]{40}${opt_quote}"
   add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -278,7 +278,7 @@ load test_helper
   repo_run git-secrets --register-aws
   git config --local --get secrets.providers
   repo_run git-secrets --list
-  echo "$output" | grep -F '[A-Z0-9]{20}'
+  echo "$output" | grep -F '(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'
   echo "$output" | grep "AKIAIOSFODNN7EXAMPLE"
   echo "$output" | grep "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 }


### PR DESCRIPTION
*Issue: #38 *
The regular expression injected by the aws-provider to match access keys, `[A-Z0-9]{20}` catches a very large number of false positives, including hashes and large randomly generated numbers.

PR #57 addresses that, but reduces the scope to just IAM access keys prefixed with `AKIA`. Additionally, it's been inactive for some time. I've been using a variant of this for a few weeks without problem, so submitting the PR. Full set of prefixes for potential keys identified at https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html.

*Description of changes:*

Restrict the regular expression intended to match access keys from `[A-Z0-9]{20}` to one which requires one of the documented prefixes so as to only rarely match randomly generated strings, hashes, and numbers.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
