### PR TITLE
Force C locale while running tests (fixes #99)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 
 # We use bats for testing: https://github.com/sstephenson/bats
 test:
-	test/bats/bin/bats test/
+	LANG=C test/bats/bin/bats test/
 
 # The man page is completely derived from README.rst. Edits to
 # README.rst require a rebuild of the man page.


### PR DESCRIPTION
*Issue #99*

Fix failing tests on non-English locales.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
