### PR TITLE
Fix typo in manpage ("inadvertantly")

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -518,7 +518,7 @@ line is unlikely to change using something like the following:
     # Outputs: 0
 
 Keep this in mind when creating allowed patterns to ensure that your allowed
-patterns are not inadvertantly matched due to the fact that the filename is
+patterns are not inadvertently matched due to the fact that the filename is
 included in the subject text that allowed patterns are matched against.
 
 

--- a/git-secrets.1
+++ b/git-secrets.1
@@ -688,7 +688,7 @@ git secrets \-\-scan /tmp/example && echo $?
 .UNINDENT
 .sp
 Keep this in mind when creating allowed patterns to ensure that your allowed
-patterns are not inadvertantly matched due to the fact that the filename is
+patterns are not inadvertently matched due to the fact that the filename is
 included in the subject text that allowed patterns are matched against.
 .SH SKIPPING VALIDATION
 .sp


### PR DESCRIPTION
Simple typo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
