### PR TITLE
Properly escape ".gitallowed" so it's not read as a macro

### DIFF
--- a/git-secrets.1
+++ b/git-secrets.1
@@ -536,7 +536,7 @@ git secrets \-\-add \-\-allowed \(aqmy regex pattern\(aq
 .UNINDENT
 .sp
 You can also add regular expressions patterns to filter false positives to a
-.gitallowed file located in the repository\(aqs root directory. Lines starting
+\&.gitallowed file located in the repository\(aqs root directory. Lines starting
 with # are skipped (comment line) and empty lines are also skipped.
 .sp
 First, git\-secrets will extract all lines from a file that contain a prohibited


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
