### PR TITLE
Fix generation of 'whatis' metadata from the manpage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,9 @@
 git-secrets
 ===========
 
-Prevents you from committing passwords and other sensitive information to a
-git repository.
+-------------------------------------------------------------------------------------------
+Prevents you from committing passwords and other sensitive information to a git repository.
+-------------------------------------------------------------------------------------------
 
 .. contents:: :depth: 2
 

--- a/git-secrets.1
+++ b/git-secrets.1
@@ -2,7 +2,7 @@
 .
 .TH GIT-SECRETS  "" "" ""
 .SH NAME
-git-secrets \- 
+git-secrets \- Prevents you from committing passwords and other sensitive information to a git repository.
 .
 .nr rst2man-indent-level 0
 .
@@ -30,9 +30,6 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.sp
-Prevents you from committing passwords and other sensitive information to a
-git repository.
 .SH SYNOPSIS
 .INDENT 0.0
 .INDENT 3.5


### PR DESCRIPTION
The description of the command was too far from the NAME section
in the manpage. This was preventing the whatis and apropos
commands from picking this up correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.