### PR TITLE
Fix heading to resolve rst2man warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Installing git-secrets
 by ``git`` when running ``git secrets``.
 
 \*nix (Linux/macOS)
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 You can use the ``install`` target of the provided Makefile to install ``git secrets`` and the man page.
 You can customize the install path using the PREFIX and MANPREFIX variables.


### PR DESCRIPTION
This fixes the following warning:

    $ rst2man README.rst > git-secrets.1 
    README.rst:43: (WARNING/2) Title underline too short.
    
    \*nix (Linux/macOS)
    ~~~~~~~~~~~~~~~~~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
