### PR TITLE
Accommodate intermediate phrases in name used to reference secret key.

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -236,7 +236,7 @@ register_aws() {
   local opt_quote="${quote}?"
   add_config 'secrets.providers' 'git secrets --aws-provider'
   add_config 'secrets.patterns' '(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'
-  add_config 'secrets.patterns' "${opt_quote}${aws}(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)${opt_quote}${connect}${opt_quote}[A-Za-z0-9/\+=]{40}${opt_quote}"
+  add_config 'secrets.patterns' "${opt_quote}${aws}_?([A-Za-z0-9]+_?)*_?(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)?${opt_quote}${connect}${opt_quote}[A-Za-z0-9/\+=]{40}${opt_quote}"
   add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'
   add_config 'secrets.allowed' "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Match secrets that may insert additional words into the name used to identify their key. Also, drop the requirement for `key` to be the final word preceding the =. This will match keys such as `AWS_IAM_SECRET_KEY` or `AWS_PROD_SECRET`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
