### PR TITLE
Fix slash on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -12,8 +12,8 @@ else
 }
 
 Write-Host "Copying files."
-Copy-Item ./git-secrets -Destination $InstallationDirectory -Force
-Copy-Item ./git-secrets.1 -Destination $InstallationDirectory -Force
+Copy-Item .\git-secrets -Destination $InstallationDirectory -Force
+Copy-Item .\git-secrets.1 -Destination $InstallationDirectory -Force
 
 Write-Host "Checking if directory already exists in Path..."
 $currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")


### PR DESCRIPTION
*Issue #, if available:* The slashes cause building the wrong file of `.git-secrets`

*Description of changes:* Fix forward-slash(Linux) to backslash(Windows).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
