### PR TITLE
Only break patterns by linebreak in the function load_combined_patterns

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -72,6 +72,7 @@ load_allowed() {
 load_combined_patterns() {
   local patterns=$(load_patterns)
   local combined_patterns=''
+  local IFS=$'\n'
   for pattern in $patterns; do
     combined_patterns=${combined_patterns}${pattern}"|"
   done

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -359,3 +359,21 @@ load test_helper
   repo_run git-secrets --list --untracked
   [ $status -eq 1 ]
 }
+
+@test "Require exact match for pattern with spaces NOT triggered" {
+  cd $TEST_REPO
+  echo 'WHITESPACE' > $TEST_REPO/ok.txt
+  git add -A
+  git commit -m "Testing pattern minus all of the spacess"
+  repo_run git-secrets --scan
+  [ $status -eq 0 ]
+}
+
+@test "Require exact match for pattern with spaces triggered" {
+  cd $TEST_REPO
+  echo 'WHITE SPACE' > $TEST_REPO/ok.txt
+  git add -A
+  git commit -m "Testing pattern with all of the spaces"
+  repo_run git-secrets --scan
+  [ $status -eq 1 ]
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -33,6 +33,7 @@ setup_repo() {
   git init
   git config --local --add secrets.patterns '@todo'
   git config --local --add secrets.patterns 'forbidden|me'
+  git config --local --add secrets.patterns 'WHITE SPACE'
   git config --local --add secrets.patterns '#hash'
   git config --local user.email "you@example.com"
   git config --local user.name "Your Name"


### PR DESCRIPTION
*Issue #120 Regexes with spaces and \s cause issues with different versions of git and grep*

*Description of changes:*

The `load_combined_patterns` function was configured to only split the patterns variable by line breaks.  This allows you to have spaces in your pattern, like:

```
password = [^ ]+
```

The `\s` pattern group is not properly recognized in all version of `grep` and `git grep`.  Also, space is a valid character that you can build a pattern around.

Additionally, two tests were added:
1. Verify that a pattern with a space in it like  `WHITE SPACE` is not split into `WHITE|SPACE`
2. Verify that a pattern with a space in it like `WHITE SPACE` will properly match

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
