### PR TITLE
Revise Windows installation command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ the directory to the current user ``PATH``.
 
 ::
 
-    PS > ./install.ps1
+    powershell -file install.ps1
 
 Homebrew (for macOS users)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
ps is the process listing command (installed as part of git bash); it does not invoke PowerShell. The command given in the readme actually overwrites install.ps1 with the output of the process list. Invoking powershell -file install.ps1 will do the job.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
