### PR TITLE
Support custom failure messages via git configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -531,6 +531,15 @@ commit, merge, or commit message. This will skip the execution of the
 git hook and allow you to make the commit or merge.
 
 
+Customizing the failure message
+-------------------
+
+Use `git config --add secrets.failureMessage <message>` to set a custom message
+to be output when a secret is found. If this configuration option is not set,
+a default message instructing users of possible mitigation strategies will
+be output.
+
+
 About
 ------
 

--- a/git-secrets
+++ b/git-secrets
@@ -148,7 +148,21 @@ process_output() {
 scan_with_fn_or_die() {
   local fn="$1"; shift
   $fn "$@" && exit 0
+  echo_failure_message
+}
+
+# Outputs the custom failure message, or the default if no custom message
+# has been set in git config secrets.failureMessage
+echo_failure_message() {
   echo >&2
+
+  local failure_message;
+  failure_message=$(git config --get-all secrets.failureMessage)
+  if [[ $? == 0 ]]; then
+    echo -e "${failure_message}" >&2
+    exit 1
+  fi
+
   echo "[ERROR] Matched one or more prohibited patterns" >&2
   echo >&2
   echo "Possible mitigations:" >&2

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -109,6 +109,25 @@ load test_helper
   [ "${lines[1]}" == "$file:2:this is forbidden right?" ]
 }
 
+@test "Prohibited matches contains standard error message" {
+  file="$TEST_REPO/test.txt"
+  echo '@todo stuff' > $file
+  repo_run git-secrets --scan $file
+  [ $status -eq 1 ]
+  [ "${lines[0]}" == "$file:1:@todo stuff" ]
+  echo "$output" | grep "Matched one or more prohibited patterns"
+}
+
+@test "Prohibited matches contains custom error message when set" {
+  git config --add secrets.failureMessage "no secrets please"
+  file="$TEST_REPO/test.txt"
+  echo '@todo stuff' > $file
+  repo_run git-secrets --scan $file
+  [ $status -eq 1 ]
+  [ "${lines[0]}" == "$file:1:@todo stuff" ]
+  echo "$output" | grep "no secrets please"
+}
+
 @test "Only matches on word boundaries" {
   file="$TEST_REPO/test.txt"
   # Note that the following does not match as it is not a word.


### PR DESCRIPTION
*Description of changes:*
Allow users to customize the failure message via git configuration option `secrets.failureMessage`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.