### PR TITLE
Allowing Perl Compatible Regex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -328,7 +328,7 @@ Options for ``--add``
     used to filter our false positives.
 
 ``<pattern>``
-    The regex pattern to search.
+    The regex pattern to search. Supports Perl Compatible Regular Expressions.
 
 
 Examples

--- a/git-secrets
+++ b/git-secrets
@@ -102,7 +102,7 @@ scan_history() {
   # Looks for differences matching the patterns, reduces the number of revisions to scan
   local to_scan=$(git log --all -G"${combined_patterns}" --pretty=%H)
   # Scan through revisions with findings to normalize output
-  output=$(GREP_OPTIONS= LC_ALL=C git grep -nwHEI "${combined_patterns}" $to_scan)
+  output=$(GREP_OPTIONS= LC_ALL=C git grep -nwHPI "${combined_patterns}" $to_scan)
   process_output $? "${output}"
 }
 
@@ -113,7 +113,7 @@ git_grep() {
   local files=("${@}") combined_patterns=$(load_combined_patterns)
 
   [ -z "${combined_patterns}" ] && return 1
-  GREP_OPTIONS= LC_ALL=C git grep -nwHEI ${options} "${combined_patterns}" -- "${files[@]}"
+  GREP_OPTIONS= LC_ALL=C git grep -nwHPI ${options} "${combined_patterns}" -- "${files[@]}"
 }
 
 # Performs a regular grep, taking into account patterns and recursion.
@@ -122,7 +122,7 @@ regular_grep() {
   local files=("${@}") patterns=$(load_patterns) action='skip'
   [ -z "${patterns}" ] && return 1
   [ ${RECURSIVE} -eq 1 ] && action="recurse"
-  GREP_OPTIONS= LC_ALL=C grep -d "${action}" -nwHEI "${patterns}" "${files[@]}"
+  GREP_OPTIONS= LC_ALL=C grep -d "${action}" -nwHPI "${patterns}" "${files[@]}"
 }
 
 # Process the given status ($1) and output variables ($2).
@@ -135,7 +135,7 @@ process_output() {
     0)
       [ -z "${allowed}" ] && echo "${output}" >&2 && return 1
       # Determine with a negative grep if the found matches are allowed
-      echo "${output}" | GREP_OPTIONS= LC_ALL=C grep -Ev "${allowed}" >&2 \
+      echo "${output}" | GREP_OPTIONS= LC_ALL=C grep -Pv "${allowed}" >&2 \
         && return 1 || return 0
       ;;
     1) return 0 ;;

--- a/git-secrets.1
+++ b/git-secrets.1
@@ -539,7 +539,7 @@ Mark the pattern as allowed instead of prohibited. Allowed patterns are
 used to filter our false positives.
 .TP
 .B \fB<pattern>\fP
-The regex pattern to search.
+The regex pattern to search. Supports Perl Compatible Regular Expressions.
 .UNINDENT
 .SS Examples
 .sp


### PR DESCRIPTION
Solves #145

Makes expressions Perl compatible by calling `grep` with the `-P` instead of the `-E` flag.
Basically, `git grep -nwHEI`, `grep -Ev` and `grep -d "${action}" -nwHEI` calls now are run with `-nwHPI` and `-Pv` flags.
Affected functions: scan_history, git_grep, regular_grep, process_output.
This doesn't break backwards compatibility since Perl Compatible Regex is a _superset_ of Extended Regex.
Also, `README.rst` and `secrets.1` now specify that PCRE is supported.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.