### PR TITLE
test_helper: make test setup more hermetic

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Disallow any system-level git-secret pattern configs
+export GIT_CONFIG_NOSYSTEM="true"
 export TEST_REPO="$BATS_TMPDIR/test-repo"
 export TEMP_HOME="$BATS_TMPDIR/home"
 export TEMPLATE_DIR="${BATS_TMPDIR}/template"
@@ -31,6 +33,9 @@ setup_repo() {
   mkdir -p $TEST_REPO
   cd $TEST_REPO
   git init
+  # Uninstall any hooks present in the system template which could interfere
+  # with git-secrets
+  rm -fr .git/hooks/*
   git config --local --add secrets.patterns '@todo'
   git config --local --add secrets.patterns 'forbidden|me'
   git config --local --add secrets.patterns '#hash'


### PR DESCRIPTION
When running tests locally outside of a container (e.g. git clone
git-secrets; make test), if a user is already using git-secrets by
default in their system config and default gitdir template, tests which
expect not to have git-secrets installed will fail. Instead, let's
remove all hooks when we create a directory without the testbench's
template and ignore the system config which may contain patterns that
conflict with the testbench.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
