### PR TITLE
Add --quiet flag to remove error message from output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Synopsis
 
 ::
 
-    git secrets --scan [-r|--recursive] [--cached] [--no-index] [--untracked] [<files>...]
+    git secrets --scan [-r|--recursive] [-q|--quiet] [--cached] [--no-index] [--untracked] [<files>...]
     git secrets --scan-history
     git secrets --install [-f|--force] [<target-directory>]
     git secrets --list [--global]
@@ -260,6 +260,9 @@ Options for ``--scan``
 
     ``-r`` cannot be used alongside ``--cached``, ``--no-index``, or
     ``--untracked``.
+
+``-q, --quiet``
+    Shows results but removes error message from output.
 
 ``--cached``
     Searches blobs registered in the index file.

--- a/git-secrets
+++ b/git-secrets
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 NONGIT_OK=1 OPTIONS_SPEC="\
-git secrets --scan [-r|--recursive] [--cached] [--no-index] [--untracked] [<files>...]
+git secrets --scan [-r|--recursive] [--cached] [-q|--quiet] [--no-index] [--untracked] [<files>...]
 git secrets --scan-history
 git secrets --install [-f|--force] [<target-directory>]
 git secrets --list [--global]
@@ -32,6 +32,7 @@ aws-provider Secret provider that outputs credentials found in an ini file
 register-aws Adds common AWS patterns to the git config and scans for ~/.aws/credentials
 r,recursive --scan scans directories recursively
 cached --scan scans searches blobs registered in the index file
+q,quiet --scan shows results but removes error message from output
 no-index --scan searches files in the current directory that is not managed by Git
 untracked In addition to searching in the tracked files in the working tree, --scan also in untracked files
 f,force --install overwrites hooks if the hook already exists
@@ -148,16 +149,18 @@ process_output() {
 scan_with_fn_or_die() {
   local fn="$1"; shift
   $fn "$@" && exit 0
-  echo >&2
-  echo "[ERROR] Matched one or more prohibited patterns" >&2
-  echo >&2
-  echo "Possible mitigations:" >&2
-  echo "- Mark false positives as allowed using: git config --add secrets.allowed ..." >&2
-  echo "- Mark false positives as allowed by adding regular expressions to .gitallowed at repository's root directory" >&2
-  echo "- List your configured patterns: git config --get-all secrets.patterns" >&2
-  echo "- List your configured allowed patterns: git config --get-all secrets.allowed" >&2
-  echo "- List your configured allowed patterns in .gitallowed at repository's root directory" >&2
-  echo "- Use --no-verify if this is a one-time false positive" >&2
+  if [ ${QUIET} -ne 1 ]; then
+    echo >&2
+    echo "[ERROR] Matched one or more prohibited patterns" >&2
+    echo >&2
+    echo "Possible mitigations:" >&2
+    echo "- Mark false positives as allowed using: git config --add secrets.allowed ..." >&2
+    echo "- Mark false positives as allowed by adding regular expressions to .gitallowed at repository's root directory" >&2
+    echo "- List your configured patterns: git config --get-all secrets.patterns" >&2
+    echo "- List your configured allowed patterns: git config --get-all secrets.allowed" >&2
+    echo "- List your configured allowed patterns in .gitallowed at repository's root directory" >&2
+    echo "- Use --no-verify if this is a one-time false positive" >&2
+  fi
   exit 1
 }
 
@@ -268,7 +271,7 @@ assert_option_for_command() {
   fi
 }
 
-declare COMMAND="$1" FORCE=0 RECURSIVE=0 LITERAL=0 GLOBAL=0 ALLOWED=0
+declare COMMAND="$1" FORCE=0 RECURSIVE=0 QUIET=0 LITERAL=0 GLOBAL=0 ALLOWED=0
 declare SCAN_CACHED=0 SCAN_NO_INDEX=0 SCAN_UNTRACKED=0
 
 # Shift off the command name
@@ -282,6 +285,10 @@ while [ "$#" -ne 0 ]; do
     -r)
       assert_option_for_command "--scan" "-r|--recursive"
       RECURSIVE=1
+      ;;
+    -q)
+      assert_option_for_command "--scan" "-q|--quiet"
+      QUIET=1
       ;;
     -a)
       assert_option_for_command "--add" "-a|--allowed"

--- a/git-secrets.1
+++ b/git-secrets.1
@@ -89,7 +89,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .sp
 .nf
 .ft C
-git secrets \-\-scan [\-r|\-\-recursive] [\-\-cached] [\-\-no\-index] [\-\-untracked] [<files>...]
+git secrets \-\-scan [\-r|\-\-recursive] [\-q|\-\-quiet] [\-\-cached] [\-\-no\-index] [\-\-untracked] [<files>...]
 git secrets \-\-scan\-history
 git secrets \-\-install [\-f|\-\-force] [<target\-directory>]
 git secrets \-\-list [\-\-global]
@@ -113,19 +113,6 @@ rejected.
 \fBgit\-secrets\fP must be placed somewhere in your PATH so that it is picked up
 by \fBgit\fP when running \fBgit secrets\fP\&.
 .SS *nix (Linux/macOS)
-.IP "System Message: WARNING/2 (README.rst:, line 43)"
-Title underline too short.
-.INDENT 0.0
-.INDENT 3.5
-.sp
-.nf
-.ft C
-\e*nix (Linux/macOS)
-~~~~~~~~~~~~~~~~~
-.ft P
-.fi
-.UNINDENT
-.UNINDENT
 .sp
 You can use the \fBinstall\fP target of the provided Makefile to install \fBgit secrets\fP and the man page.
 You can customize the install path using the PREFIX and MANPREFIX variables.
@@ -428,6 +415,9 @@ ignored.
 .sp
 \fB\-r\fP cannot be used alongside \fB\-\-cached\fP, \fB\-\-no\-index\fP, or
 \fB\-\-untracked\fP\&.
+.TP
+.B \fB\-q, \-\-quiet\fP
+Shows results but removes error message from output.
 .TP
 .B \fB\-\-cached\fP
 Searches blobs registered in the index file.

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -311,6 +311,14 @@ load test_helper
   [ $status -eq 0 ]
 }
 
+@test "-q removes error message from output" {
+  setup_bad_repo
+  repo_run git-secrets --scan
+  echo "$output" | grep "ERROR"
+  repo_run git-secrets --scan -q
+  [[ ! $output =~ "ERROR" ]]
+}
+
 @test "--recursive cannot be used with SCAN_*" {
   repo_run git-secrets --scan -r --cached
   [ $status -eq 1 ]
@@ -357,5 +365,10 @@ load test_helper
 
 @test "--untracked can only be used with --scan" {
   repo_run git-secrets --list --untracked
+  [ $status -eq 1 ]
+}
+
+@test "-q can only be used with --scan" {
+  repo_run git-secrets --list -q
   [ $status -eq 1 ]
 }


### PR DESCRIPTION
*Issue:* #157

*Description of changes:* Adds support for a --quiet flag for use with the --scan command to remove error message from output.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
