### PR TITLE
include prohibited regular expressions from a .gitprohibited file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -403,6 +403,9 @@ like Ubuntu (BSD vs GNU).
 You can add prohibited regular expression patterns to your git config using
 ``git secrets --add <pattern>``.
 
+You can also add prohibited regular expressions patterns to a
+``.gitprohibited`` file located in the repository's root directory. Lines starting
+with ``#`` are skipped (comment line) and empty lines are also skipped.
 
 Ignoring false positives
 ------------------------

--- a/git-secrets
+++ b/git-secrets
@@ -47,6 +47,10 @@ prepare_commit_msg_hook* prepare-commit-msg hook (internal only)"
 
 load_patterns() {
   git config --get-all secrets.patterns
+  local gitprohibited="$(git rev-parse --show-toplevel)/.gitprohibited"
+  if [ -e "$gitprohibited" ]; then
+    cat $gitprohibited | awk 'NF && $1!~/^#/'
+  fi
   # Execute each provider and use their output to build up patterns
   git config --get-all secrets.providers | while read -r cmd; do
     # Only split words on '\n\t ' and strip "\r" from the output to account


### PR DESCRIPTION
Update git-secrets to include prohibited regular expressions from a .gitprohibited file

*Issue #, if available:*

Add the possibility of using a ``.gitprohibited`` file in the repository root to include prohibited patterns - much the same as ``.gitallowed`` is used to mark false positives


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
