### PR TITLE
Change `--list` to only search for `secrets` section and not everything

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -338,9 +338,9 @@ case "${COMMAND}" in
   --scan-history) scan_with_fn_or_die "scan_history" "$@" ;;
   --list)
     if [ ${GLOBAL} -eq 1 ]; then
-      git config --global --get-regex secrets.*
+      git config --global --get-regex "^secrets.*"
     else
-      git config --get-regex secrets.*
+      git config --get-regex "^secrets.*"
     fi
     ;;
   --install)


### PR DESCRIPTION
*Description of changes:*

I stumbled over a problematic situation, because my `git config` had some content with `secrets` in it. The config that had this in it is:
```
[branch "ll-INV-add-git-secrets"]
	remote = origin
	merge = refs/heads/ll-INV-add-git-secrets
```

When running `git secrets --list`, it showed me two files because the regex is not looking for the section but just for any `secrets.*` string.

With this change, `git secrets --list` only returns the configuration in the `secrets` section of git

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
