### PR TITLE
Typo - "filter our false positives"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -325,7 +325,7 @@ Options for ``--add``
 
 ``-a, --allowed``
     Mark the pattern as allowed instead of prohibited. Allowed patterns are
-    used to filter our false positives.
+    used to filter out false positives.
 
 ``<pattern>``
     The regex pattern to search.

--- a/git-secrets.1
+++ b/git-secrets.1
@@ -536,7 +536,7 @@ that the pattern is searched for literally.
 .TP
 .B \fB\-a, \-\-allowed\fP
 Mark the pattern as allowed instead of prohibited. Allowed patterns are
-used to filter our false positives.
+used to filter out false positives.
 .TP
 .B \fB<pattern>\fP
 The regex pattern to search.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
"filter our false positives" should be "filter out false positives" in manpage and website README.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
