### PR TITLE
Added support for linux on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: bash
-
+arch:
+  - amd64
+  - ppc64le
 before_install:
 - git config --global user.email "you@example.com"
 - git config --global user.name "Your Name"


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/git-secrets/builds/187456783
Please have a look.

Regards,
ujjwal
