### PR TITLE
Don't assume HEAD is a symref in prepare-commit-msg hook.

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -185,9 +185,7 @@ prepare_commit_msg_hook() {
     merge,)
       local git_head=$(env | grep GITHEAD)  # e.g. GITHEAD_<sha>=release/1.43
       local sha="${git_head##*=}"           # Get just the SHA
-      local branch=$(git symbolic-ref HEAD) # e.g. refs/heads/master
-      local dest="${branch#refs/heads/}"    # cut out "refs/heads"
-      git log "${dest}".."${sha}" -p | scan_with_fn_or_die "scan" -
+      git log HEAD.."${sha}" -p | scan_with_fn_or_die "scan" -
       ;;
   esac
 }

--- a/test/prepare-commit-msg.bats
+++ b/test/prepare-commit-msg.bats
@@ -31,3 +31,34 @@ load test_helper
   run git merge --no-ff feature
   [ $status -eq 0 ]
 }
+
+@test "Works with detached HEAD" {
+  setup_good_repo
+  repo_run git-secrets --install
+  cd $TEST_REPO
+  git commit -m 'OK'
+  git checkout -b branchA
+  echo "A" > a.txt
+  git add -A
+  git commit -m "Commit to branchA"
+  git checkout -f $(git rev-parse master)
+  run git merge --no-ff branchA
+  [ -z "$( echo $output | grep fatal )" ]
+}
+
+@test "Rejects bad merge with detached HEAD" {
+  setup_good_repo
+  repo_run git-secrets --install $TEST_REPO
+  cd $TEST_REPO
+  git commit -m 'OK'
+  git checkout -b feature
+  echo '@todo' > data.txt
+  git add -A
+  git commit -m 'Bad commit' --no-verify
+  echo 'Fixing!' > data.txt
+  git add -A
+  git commit -m 'Fixing commit'
+  git checkout -f $(git rev-parse master)
+  run git merge --no-ff feature
+  [ $status -eq 1 ]
+}


### PR DESCRIPTION
prepare-commit-msg generates spurious error messages when HEAD is
detached. Use a simpler log command to avoid these errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
