### PR TITLE
Fix for issue where git-secrets could fail on Windows if enough files…

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -113,7 +113,7 @@ git_grep() {
   local files=("${@}") combined_patterns=$(load_combined_patterns)
 
   [ -z "${combined_patterns}" ] && return 1
-  GREP_OPTIONS= LC_ALL=C echo "${files[@]}" | xargs git grep -nwHEI ${options} "${combined_patterns}"
+  GREP_OPTIONS= LC_ALL=C printf "%s\0" "${files[@]}" | xargs -0 git grep -nwHEI ${options} "${combined_patterns}"
   rc=$?
   [ $rc -eq 123 ] && return 1 # xargs returns 123 when the invocations return a value between 1-125
   [ $rc -eq 0 ] && return 0

--- a/git-secrets
+++ b/git-secrets
@@ -114,6 +114,10 @@ git_grep() {
 
   [ -z "${combined_patterns}" ] && return 1
   GREP_OPTIONS= LC_ALL=C echo "${files[@]}" | xargs git grep -nwHEI ${options} "${combined_patterns}"
+  rc=$?
+  [ $rc -eq 123 ] && return 1 # xargs returns 123 when the invocations return a value between 1-125
+  [ $rc -eq 0 ] && return 0
+  return $rc
 }
 
 # Performs a regular grep, taking into account patterns and recursion.

--- a/git-secrets
+++ b/git-secrets
@@ -113,7 +113,7 @@ git_grep() {
   local files=("${@}") combined_patterns=$(load_combined_patterns)
 
   [ -z "${combined_patterns}" ] && return 1
-  GREP_OPTIONS= LC_ALL=C git grep -nwHEI ${options} "${combined_patterns}" -- "${files[@]}"
+  GREP_OPTIONS= LC_ALL=C echo "${files[@]}" | xargs git grep -nwHEI ${options} "${combined_patterns}"
 }
 
 # Performs a regular grep, taking into account patterns and recursion.
@@ -139,7 +139,9 @@ process_output() {
         && return 1 || return 0
       ;;
     1) return 0 ;;
-    *) exit $status
+    *)
+       echo "${output}" >&2
+       exit $status
   esac
 }
 

--- a/git-secrets
+++ b/git-secrets
@@ -113,7 +113,12 @@ git_grep() {
   local files=("${@}") combined_patterns=$(load_combined_patterns)
 
   [ -z "${combined_patterns}" ] && return 1
-  GREP_OPTIONS= LC_ALL=C printf "%s\0" "${files[@]}" | xargs -0 git grep -nwHEI ${options} "${combined_patterns}"
+  if (( ${#files[@]} )); then
+    GREP_OPTIONS= LC_ALL=C printf "%s\0" "${files[@]}" | xargs -0 git grep -nwHEI ${options} "${combined_patterns}"
+  else
+    GREP_OPTIONS= LC_ALL=C git grep -nwHEI ${options} "${combined_patterns}"
+  fi
+
   rc=$?
   [ $rc -eq 123 ] && return 1 # xargs returns 123 when the invocations return a value between 1-125
   [ $rc -eq 0 ] && return 0


### PR DESCRIPTION
… where modified to be over the 32727 command line length

When git-secrets is run, for all filepaths that are part of the staged list of changes they get passed into an invocation of `git grep`
If there is a large number of staged files, depending on the length of each file path from the git repo root, it could result in an extremely long line being supplied to `git grep`
For example if the git structure is as below
```
/
  Include/
    TestLibrary/
      MyTestComponent1.h
      MyTestComponent2.h
...
      MyTestComponent1000.h
```

It would take around changes to 900 `Include/TestLibrary/MyTestComponentNNNN.h` files within the repo to cause the `git grep` to be passed an argument list that is too long

*Issue #192, if available:*

*Description of changes:*
Fixed issue where git secrets could fail if the bash invocation of `git grep` within the git-secrets shell script passed enough file paths that caused the command line invocation for `git grep` to be over 32767 characters

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
