### PR TITLE
Add perl-like regex compatibility to git grep cmd.

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -102,7 +102,7 @@ scan_history() {
   # Looks for differences matching the patterns, reduces the number of revisions to scan
   local to_scan=$(git log --all -G"${combined_patterns}" --pretty=%H)
   # Scan through revisions with findings to normalize output
-  output=$(GREP_OPTIONS= LC_ALL=C git grep -nwHEI "${combined_patterns}" $to_scan)
+  output=$(GREP_OPTIONS= LC_ALL=C git grep -nwHEIP "${combined_patterns}" $to_scan)
   process_output $? "${output}"
 }
 
@@ -113,7 +113,7 @@ git_grep() {
   local files=("${@}") combined_patterns=$(load_combined_patterns)
 
   [ -z "${combined_patterns}" ] && return 1
-  GREP_OPTIONS= LC_ALL=C git grep -nwHEI ${options} "${combined_patterns}" -- "${files[@]}"
+  GREP_OPTIONS= LC_ALL=C git grep -nwHEIP ${options} "${combined_patterns}" -- "${files[@]}"
 }
 
 # Performs a regular grep, taking into account patterns and recursion.
@@ -122,7 +122,7 @@ regular_grep() {
   local files=("${@}") patterns=$(load_patterns) action='skip'
   [ -z "${patterns}" ] && return 1
   [ ${RECURSIVE} -eq 1 ] && action="recurse"
-  GREP_OPTIONS= LC_ALL=C grep -d "${action}" -nwHEI "${patterns}" "${files[@]}"
+  GREP_OPTIONS= LC_ALL=C grep -d "${action}" -nwHEIP "${patterns}" "${files[@]}"
 }
 
 # Process the given status ($1) and output variables ($2).


### PR DESCRIPTION
# WHAT
Add perl-like regex compatibility to git grep command.

# WHY
To support the regexes here that use `(?i)` to search with case-insensitivity.