### PR TITLE
Resolve Empty AWS Credentials Issue

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -253,7 +253,7 @@ aws_provider() {
   [ -z "$fi" ] && fi=~/.aws/credentials
   # Find keys and ensure that special characters are escaped.
   if [ -f $fi ]; then
-    awk -F "=" '/aws_access_key_id|aws_secret_access_key/ {print $2}' $fi \
+    awk -F "=" '/aws_access_key_id|aws_secret_access_key/ && $2 {print $2}' $fi \
       | tr -d ' "' \
       | sed 's/[]\.|$(){}?+*^]/\\&/g'
   fi


### PR DESCRIPTION


*Issue #, if available:*
When committing anything on your machine where there are empty entries in your default aws credentials file such as
aws_access_key_id=
aws_secret_access_key=
aws_session_token=
git-secrets triggers on every file everywhere.
*Description of changes:*
This will prevent the empty values from getting pull in to check the regexes against. 
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
