### PR TITLE
gracefully handle git secrets not being installed

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -203,7 +203,13 @@ install_hook() {
   [ -f "${dest}" ] && [ "${FORCE}" -ne 1 ] \
     && die "${dest} already exists. Use -f to force"
   echo "#!/usr/bin/env bash" > "${dest}"
-  echo "git secrets --${cmd} -- \"\$@\"" >> "${dest}"
+  echo "err=\"\$(git secrets --${cmd} -- \"\$@\" 2>&1 > /dev/null)\"" >> "${dest}"
+  echo "if [[ \"\$err\" == *\"git: 'secrets' is not a git command\"* ]]; then" >> "${dest}"
+  echo "  exit 0" >> "${dest}"
+  echo "else" >> "${dest}"
+  echo "  >&2 echo \"\$err\"" >> "${dest}"
+  echo "  exit 1" >> "${dest}"
+  echo "fi" >> "${dest}"
   chmod +x "${dest}"
   say "$(tput setaf 2)✓$(tput sgr 0) Installed ${hook} hook to ${dest}"
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For whatever reason, sometimes the env does not have access to git secrets (for example in `vscode` this seems to happen frequently). This change allows it to fail gracefully instead of blocking all commits.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
