### PR TITLE
Explicitly set initial branch for tests

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -30,7 +30,7 @@ setup_repo() {
   delete_repo
   mkdir -p $TEST_REPO
   cd $TEST_REPO
-  git init
+  git init --initial-branch=master
   git config --local --add secrets.patterns '@todo'
   git config --local --add secrets.patterns 'forbidden|me'
   git config --local --add secrets.patterns '#hash'


### PR DESCRIPTION
*Description of changes:*

Add `--initial-branch=master` to `git init` in the test repo setup. Without this, tests will encounter errors and fail when run in an environment with a different default initial branch name, such as the recently popular `main`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
