### PR TITLE
Only emit terminal codes to terminal (and don't require `say`)

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -205,7 +205,8 @@ install_hook() {
   echo "#!/usr/bin/env bash" > "${dest}"
   echo "git secrets --${cmd} -- \"\$@\"" >> "${dest}"
   chmod +x "${dest}"
-  say "$(tput setaf 2)✓$(tput sgr 0) Installed ${hook} hook to ${dest}"
+  [ -t 1 ] && which tput >/dev/null && echo -n "$(tput setaf 2)✓$(tput sgr 0) "
+  echo "Installed ${hook} hook to ${dest}"
 }
 
 install_all_hooks() {

--- a/git-secrets
+++ b/git-secrets
@@ -205,7 +205,7 @@ install_hook() {
   echo "#!/usr/bin/env bash" > "${dest}"
   echo "git secrets --${cmd} -- \"\$@\"" >> "${dest}"
   chmod +x "${dest}"
-  [ -t 1 ] && which tput >/dev/null && echo -n "$(tput setaf 2)✓$(tput sgr 0) "
+  [ -t 1 ] && command -v tput &> /dev/null && echo -n "$(tput setaf 2)✓$(tput sgr 0) "
   echo "Installed ${hook} hook to ${dest}"
 }
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes #220
Fixes #239

*Description of changes:*
* Check for presence of tput and for stdout being a terminal before emitting terminal control codes.
* Remove unnecessary dependence on `say` (which was removed: https://github.com/git/git/commit/5b893f7d81eb7feb43662ed8663e2af76a76b4c8)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
