### PR TITLE
Replaced say function to echo

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -205,7 +205,7 @@ install_hook() {
   echo "#!/usr/bin/env bash" > "${dest}"
   echo "git secrets --${cmd} -- \"\$@\"" >> "${dest}"
   chmod +x "${dest}"
-  say "$(tput setaf 2)✓$(tput sgr 0) Installed ${hook} hook to ${dest}"
+  echo "$(tput setaf 2)✓$(tput sgr 0) Installed ${hook} hook to ${dest}"
 }
 
 install_all_hooks() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

"say" functions is removed from git-sh-setup.

https://github.com/git/git/commit/5b893f7d81eb7feb43662ed8663e2af76a76b4c8

Replaced “say” to “echo”.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
