### PR TITLE
pre-commit hook can be run without installing git-secrets

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 -   id: git-secrets
     name: Git Secrets
     description: git-secrets scans commits, commit messages, and --no-ff merges to prevent adding secrets into your git repositories.
-    entry: 'git-secrets --pre_commit_hook'
+    entry: pre-commit-hook-exec.sh
     language: script

--- a/pre-commit-hook-exec.sh
+++ b/pre-commit-hook-exec.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# pre-commit clones the git repo to a cache-directory that it manages.
+# The entry script is executed using the absolute path to this cache-directory
+# so we can use this to locate the git-secrets script and add it to PATH
+# without requiring the user to manually install it.
+
+set -eu
+
+PARENTDIR=$(dirname "${BASH_SOURCE}")
+export PATH="$PARENTDIR:$PATH"
+exec git secrets --pre_commit_hook "$@"


### PR DESCRIPTION
*Issue #, if available:* -

*Description of changes:*
At present if you want to use the git-secrets pre-commit hook you must first follow the git-secrets installation instructions. In contrast many other pre-commit hooks are designed to be self-contained, they automatically install themselves to a directory controlled by pre-commit when `pre-commit run` is called. This improves the developer experience of projects using this hook, since new developers can just run `pre-commit ...` without any pre-requisite setup.

This PR changes the pre-commit hook `entry` to a wrapper script that detects the location of the cloned git-secrets directory, and adds it to `PATH` so `git secrets` can be run without any manual setup.

A further benefit is that the version of git-secrets used will match the git revision specified in the `.pre-commit-config.yaml` instead of whatever version the user has installed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
