### PR TITLE
Added --name-only option

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 
 NONGIT_OK=1 OPTIONS_SPEC="\
-git secrets --scan [-r|--recursive] [--cached] [--no-index] [--untracked] [<files>...]
+git secrets --scan [-r|--recursive] [--cached] [--name-only] [--no-index] [--untracked] [<files>...]
 git secrets --scan-history
 git secrets --install [-f|--force] [<target-directory>]
 git secrets --list [--global]
@@ -32,6 +32,7 @@ aws-provider Secret provider that outputs credentials found in an ini file
 register-aws Adds common AWS patterns to the git config and scans for ~/.aws/credentials
 r,recursive --scan scans directories recursively
 cached --scan scans searches blobs registered in the index file
+name-only --scan shows only file names that contain secrets, not the secrets themselves
 no-index --scan searches files in the current directory that is not managed by Git
 untracked In addition to searching in the tracked files in the working tree, --scan also in untracked files
 f,force --install overwrites hooks if the hook already exists
@@ -84,6 +85,7 @@ scan() {
   local files=("${@}") options=""
   [ "${SCAN_CACHED}" == 1 ] && options+="--cached"
   [ "${SCAN_UNTRACKED}" == 1 ] && options+=" --untracked"
+  [ "${SCAN_NAME_ONLY}" == 1 ] && options+=" --name-only"
   [ "${SCAN_NO_INDEX}" == 1 ] && options+=" --no-index"
   # Scan using git-grep if there are no files or if git options are applied.
   if [ ${#files[@]} -eq 0 ] || [ ! -z "${options}" ]; then
@@ -269,7 +271,7 @@ assert_option_for_command() {
 }
 
 declare COMMAND="$1" FORCE=0 RECURSIVE=0 LITERAL=0 GLOBAL=0 ALLOWED=0
-declare SCAN_CACHED=0 SCAN_NO_INDEX=0 SCAN_UNTRACKED=0
+declare SCAN_CACHED=0 SCAN_NAME_ONLY=0 SCAN_NO_INDEX=0 SCAN_UNTRACKED=0
 
 # Shift off the command name
 shift 1
@@ -294,6 +296,10 @@ while [ "$#" -ne 0 ]; do
     --cached)
       assert_option_for_command "--scan" "--cached"
       SCAN_CACHED=1
+      ;;
+    --name-only)
+      assert_option_for_command "--scan" "--name-only"
+      SCAN_NAME_ONLY=1
       ;;
     --no-index)
       assert_option_for_command "--scan" "--no-index"

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -72,6 +72,18 @@ load test_helper
   [ $status -eq 1 ]
 }
 
+@test "Scans all files displaying file name only - pass" {
+  setup_good_repo
+  repo_run git-secrets --scan --name-only
+  [ $status -eq 0 ]
+}
+
+@test "Scans all files displaying file name only - fail" {
+  setup_bad_repo
+  repo_run git-secrets --scan --name-only
+  [ $status -eq 1 ]
+}
+
 @test "Scans recursively" {
   setup_bad_repo
   mkdir -p $TEST_REPO/foo/bar/baz
@@ -347,6 +359,11 @@ load test_helper
 
 @test "--cached can only be used with --scan" {
   repo_run git-secrets --list --cached
+  [ $status -eq 1 ]
+}
+
+@test "--name-only can only be used with --scan" {
+  repo_run git-secrets --list --name-only
   [ $status -eq 1 ]
 }
 


### PR DESCRIPTION
Description of changes:
* Added `--name-only` command line option
* Added unit tests

The PR adds a `--name-only` option, to print only the file name containing the secret, not the secret value itself.

This is for useful for CICD processes, in the case that someone actually commits and pushes a credential that gets caught by the CICD script.  You want the file to get flagged, but you don't want the actual credential echoed into the CICD log files.

This is a potential solution for [Issue #187](https://github.com/awslabs/git-secrets/issues/187)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
