### PR TITLE
Avoid scanning of entire repo when a file is deleted

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -177,7 +177,7 @@ pre_commit_hook() {
     [ -n "$file" ] && files+=("$file")
   done <<< "$(git diff-index --diff-filter 'ACMU' --name-only --cached $rev --)"
   # when the file list empty, then don't all the scan, otherwise it will start scanning entire repo
-  [ -z "${files[@]}" ] && return
+  [[ -z "${files[@]}" ]] && return
   scan_with_fn_or_die "scan" "${files[@]}"
 }
 


### PR DESCRIPTION
*Issue #, if available:*

The git secrets scan the entire repo when the file is removed. For large repos, this impacts the user experience, if they are using any IDE for development, developers need to use the terminal to force git secrets to skip the scan with `--no-verify` option.

*Description of changes:*

This change is done when no files are returned, and then pre_commit_hook will gracefully return instead of calling scan_with_fn_or_die function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
