### PR TITLE
fix: add more examples during register aws

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -240,6 +240,9 @@ register_aws() {
   add_config 'secrets.patterns' "${opt_quote}${aws}(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)${opt_quote}${connect}${opt_quote}[A-Za-z0-9/\+=]{40}${opt_quote}"
   add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'
+  add_config 'secrets.allowed' 'AKIAI44QH8DHBEXAMPLE'
+  add_config 'secrets.allowed' 'ASIAIOSFODNN7EXAMPLE'
+  add_config 'secrets.allowed' 'ASIAI44QH8DHBEXAMPLE'
   add_config 'secrets.allowed' "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 
   if [[ $? == 0 ]]; then

--- a/git-secrets
+++ b/git-secrets
@@ -246,6 +246,7 @@ register_aws() {
   add_config 'secrets.allowed' 'ASIAIOSFODNN7EXAMPLE'
   add_config 'secrets.allowed' 'ASIAI44QH8DHBEXAMPLE'
   add_config 'secrets.allowed' "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  add_config 'secrets.allowed' "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY"
 
   if [[ $? == 0 ]]; then
     echo 'OK'


### PR DESCRIPTION
*Issue #, if available:*

#262 

*Description of changes:*

Add short-term and long-term examples:

* ASIAIOSFODNN7EXAMPLE
* ASIAI44QH8DHBEXAMPLE
* AKIAI44QH8DHBEXAMPLE

https://github.com/awslabs/git-secrets/blob/5357e18bc27b42a827b6780564ea873a72ca1f01/git-secrets#L242-L243

from https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html:

short term:
> ```
> [default]
> aws_access_key_id=ASIAIOSFODNN7EXAMPLE
> aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
> aws_session_token = IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZVERYLONGSTRINGEXAMPLE
>
> [user1]
> aws_access_key_id=ASIAI44QH8DHBEXAMPLE
> aws_secret_access_key=je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY
> aws_session_token = fcZib3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZVERYLONGSTRINGEXAMPLE```
> ```

long-term:
> ```
> [default]
> aws_access_key_id=AKIAIOSFODNN7EXAMPLE
> aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
> 
> [user1]
> aws_access_key_id=AKIAI44QH8DHBEXAMPLE
> aws_secret_access_key=je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY
> ```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
