### PR TITLE
feat: Amazon Bedrock API key patterns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,7 @@ Each of these options must appear first on the command line.
     checks are added:
 
     - AWS Access Key IDs via ``(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}``
+    - Amazon Bedrock API keys. Long-lived via ``ABSK[A-Za-z0-9+/]{109,}=*`` and short-lived via ``bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t``
     - AWS Secret Access Key assignments via ":" or "=" surrounded by optional
       quotes
     - AWS account ID assignments via ":" or "=" surrounded by optional quotes

--- a/git-secrets
+++ b/git-secrets
@@ -237,6 +237,8 @@ register_aws() {
   local opt_quote="${quote}?"
   add_config 'secrets.providers' 'git secrets --aws-provider'
   add_config 'secrets.patterns' '(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'
+  add_config 'secrets.patterns' 'ABSK[A-Za-z0-9+/]{109,}=*' #Bedrock long-lived - https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
+  add_config 'secrets.patterns' 'bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t' #Bedrock short-lived - https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
   add_config 'secrets.patterns' "${opt_quote}${aws}(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)${opt_quote}${connect}${opt_quote}[A-Za-z0-9/\+=]{40}${opt_quote}"
   add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'

--- a/git-secrets.1
+++ b/git-secrets.1
@@ -286,6 +286,8 @@ checks are added:
 .IP \(bu 2
 AWS Access Key IDs via \fB(A3T[A\-Z0\-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A\-Z0\-9]{16}\fP
 .IP \(bu 2
+Amazon Bedrock API keys. Long\-lived via \fBABSK[A-Za-z0-9+/]{109,}=*\fP and short\-lived via \fBbedrock\-api\-key\-YmVkcm9jay5hbWF6b25hd3MuY29t\fP
+.IP \(bu 2
 AWS Secret Access Key assignments via ":" or "=" surrounded by optional
 quotes
 .IP \(bu 2

--- a/test/git-secrets.bats
+++ b/test/git-secrets.bats
@@ -281,6 +281,8 @@ load test_helper
   echo "$output" | grep -F '(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'
   echo "$output" | grep "AKIAIOSFODNN7EXAMPLE"
   echo "$output" | grep "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  echo "$output" | grep -F 'ABSK[A-Za-z0-9+/]{109,}=*'
+  echo "$output" | grep -F 'bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t'
 }
 
 @test "Adds providers" {


### PR DESCRIPTION
*Description of changes:*

Add secret detection of [Amazon Bedrock API Keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-how.html)

- Long-lived via `ABSK[A-Za-z0-9+/]{109,}=*` - [Note 1]
- Short-lived via `bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t`

[Note 1] - Ideally this would have been `(?<![A-Za-z0-9+/=])ABSK[A-Za-z0-9+/]{109,269}={0,2}(?![A-Za-z0-9+/=])` but to allow for compatibility for BSD grep I relaxed it a bit.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
