### PR TITLE
fix:grep warning;remove unneeded escapes on amazon ID dashes

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -240,7 +240,7 @@ register_aws() {
   add_config 'secrets.patterns' 'ABSK[A-Za-z0-9+/]{109,}=*' #Bedrock long-lived - https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
   add_config 'secrets.patterns' 'bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t' #Bedrock short-lived - https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
   add_config 'secrets.patterns' "${opt_quote}${aws}(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)${opt_quote}${connect}${opt_quote}[A-Za-z0-9/\+=]{40}${opt_quote}"
-  add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
+  add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}-?[0-9]{4}-?[0-9]{4}${opt_quote}"
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'
   add_config 'secrets.allowed' "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 


### PR DESCRIPTION
amazon id format 1234-5678-9012 (4#-4#-4#) dash - does not require an escape. backslash has no use there and causes grep warnings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

fixes: [217](https://github.com/awslabs/git-secrets/issues/217)
