### PR TITLE
fix: hard coded short-lived bedrock to regex

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -238,7 +238,7 @@ register_aws() {
   add_config 'secrets.providers' 'git secrets --aws-provider'
   add_config 'secrets.patterns' '(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'
   add_config 'secrets.patterns' 'ABSK[A-Za-z0-9+/]{109,}=*' #Bedrock long-lived - https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
-  add_config 'secrets.patterns' 'bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t' #Bedrock short-lived - https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
+  add_config 'secrets.patterns' 'bedrock-api-key-[A-Za-z0-9_-]{28}' #Bedrock short-lived - https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
   add_config 'secrets.patterns' "${opt_quote}${aws}(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)${opt_quote}${connect}${opt_quote}[A-Za-z0-9/\+=]{40}${opt_quote}"
   add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'


### PR DESCRIPTION
>[!WARNING]
>Unsure if intentionally hard coded.

Changes hard coded short-lived bedrock api key into a regex.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

fixes: [269](https://github.com/awslabs/git-secrets/issues/269)