### PR TITLE
fix(bedrock): Short-lived pattern to regex

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ Each of these options must appear first on the command line.
     checks are added:
 
     - AWS Access Key IDs via ``(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}``
-    - Amazon Bedrock API keys. Long-lived via ``ABSK[A-Za-z0-9+/]{109,}=*`` and short-lived via ``bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t``
+    - Amazon Bedrock API keys. Long-lived via ``ABSK[A-Za-z0-9+/]{109,}=*`` and short-lived via ``bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t[a-zA-Z0-9]{1,}``
     - AWS Secret Access Key assignments via ":" or "=" surrounded by optional
       quotes
     - AWS account ID assignments via ":" or "=" surrounded by optional quotes

--- a/git-secrets
+++ b/git-secrets
@@ -238,7 +238,7 @@ register_aws() {
   add_config 'secrets.providers' 'git secrets --aws-provider'
   add_config 'secrets.patterns' '(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'
   add_config 'secrets.patterns' 'ABSK[A-Za-z0-9+/]{109,}=*' #Bedrock long-lived - https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
-  add_config 'secrets.patterns' 'bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t' #Bedrock short-lived - https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
+  add_config 'secrets.patterns' 'bedrock-api-key-YmVkcm9jay5hbWF6b25hd3MuY29t[a-zA-Z0-9]{1,}' #Bedrock short-lived - https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-generate.html
   add_config 'secrets.patterns' "${opt_quote}${aws}(SECRET|secret|Secret)?_?(ACCESS|access|Access)?_?(KEY|key|Key)${opt_quote}${connect}${opt_quote}[A-Za-z0-9/\+=]{40}${opt_quote}"
   add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'

--- a/git-secrets.1
+++ b/git-secrets.1
@@ -286,7 +286,7 @@ checks are added:
 .IP \(bu 2
 AWS Access Key IDs via \fB(A3T[A\-Z0\-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A\-Z0\-9]{16}\fP
 .IP \(bu 2
-Amazon Bedrock API keys. Long\-lived via \fBABSK[A-Za-z0-9+/]{109,}=*\fP and short\-lived via \fBbedrock\-api\-key\-YmVkcm9jay5hbWF6b25hd3MuY29t\fP
+Amazon Bedrock API keys. Long\-lived via \fBABSK[A-Za-z0-9+/]{109,}=*\fP and short\-lived via \fBbedrock\-api\-key\-YmVkcm9jay5hbWF6b25hd3MuY29t[a-zA-Z0-9]{1,}\fP
 .IP \(bu 2
 AWS Secret Access Key assignments via ":" or "=" surrounded by optional
 quotes


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/git-secrets/issues/269

*Description of changes:*

Updated Bedrock API keys short-lived from simple substr regex to more complex. Aim is to prefix secrets being detected in `git-secrets` source itself

Note: The `YmVkcm9jay5hbWF6b25hd3MuY29t` Base64 value which decodes to `bedrock.amazonaws.com`. This is included to reduce false positives.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
